### PR TITLE
feat: add reusable CodeBlock and unify code styling across landing an…

### DIFF
--- a/docs/src/app/components/CodeBlocks.jsx
+++ b/docs/src/app/components/CodeBlocks.jsx
@@ -1,0 +1,22 @@
+/**
+ * GitHub Dark Default styled code block for the landing page.
+ * Uses CSS variables from globals.css for theme consistency.
+ */
+export function CodeBlock({ children, ...props }) {
+  return (
+    <pre
+      style={{
+        backgroundColor: 'var(--code-bg)',
+        color: 'var(--code-text)',
+        borderRadius: '8px',
+        overflow: 'auto',
+        margin: 0,
+        lineHeight: '1.5',
+        fontFamily: 'Consolas, Monaco, "Courier New", monospace',
+        fontSize: props.style?.fontSize || '16px',
+      }}
+    >
+      <code {...props}>{children}</code>
+    </pre>
+  )
+}

--- a/docs/src/app/globals.css
+++ b/docs/src/app/globals.css
@@ -5,6 +5,22 @@
   --background-end-rgb: 255, 255, 255;
 }
 
+/* GitHub Dark Default theme for code blocks */
+:root {
+  --code-bg: #010102;
+  --code-text: #c9d1d9;
+  --code-keyword: #ff7b72; /* import, from, const, return */
+  --code-string: #a5d6ff; /* 'strings' */
+  --code-function: #d2a8ff; /* function calls */
+  --code-comment: #8b949e; /* comments */
+  --code-identifier: #79c0ff; /* identifiers, props */
+  --code-number: #79c0ff; /* numbers */
+  --code-boolean: #ff7b72; /* true, false */
+  --code-type: #7ee787; /* types */
+  --code-operator: #c9d1d9; /* operators */
+  --code-punctuation: #c9d1d9; /* brackets, semicolons */
+}
+
 /* Dark mode variables */
 .dark {
   --foreground-rgb: 255, 255, 255;

--- a/docs/src/app/page.jsx
+++ b/docs/src/app/page.jsx
@@ -1,4 +1,5 @@
 import Link from 'next/link'
+import { CodeBlock } from './components/CodeBlocks'
 
 export default function HomePage() {
   return (
@@ -83,30 +84,40 @@ export default function HomePage() {
           <div style={{
             maxWidth: '700px',
             margin: '0 auto',
-            background: 'rgba(255,255,255,0.05)',
-            border: '1px solid rgba(255,255,255,0.1)',
+            background: 'var(--code-bg)',
             borderRadius: '16px',
+            border: '1px solid rgba(255,255,255,0.2)',
             padding: '32px',
-            textAlign: 'left'
+            textAlign: 'left',
           }}>
-            <pre style={{
-              fontSize: '16px',
-              color: '#e5e5e5',
-              overflow: 'auto',
-              margin: 0
-            }}>
-              {`import { validate, format } from 'rut.ts'
-
-// Validate any RUT format
-validate('12.345.678-5') // → true
-
-// Format with dots and hyphen
-format('123456785') // → '12.345.678-5'
-
-// Incremental formatting
-format('1234', { incremental: true })
-// → '1.234'`}
-            </pre>
+            <CodeBlock>
+              <span style={{ color: 'var(--code-keyword)' }}>import</span> {'{ '}
+              <span style={{ color: 'var(--code-identifier)' }}>validate</span>,{' '}
+              <span style={{ color: 'var(--code-identifier)' }}>format</span>
+              {' }'} <span style={{ color: 'var(--code-keyword)' }}>from</span>{' '}
+              <span style={{ color: 'var(--code-string)' }}>'rut.ts'</span>
+              {'\n\n'}
+              <span style={{ color: 'var(--code-gray)' }}>// Validate any RUT format</span>
+              {'\n'}
+              <span style={{ color: 'var(--code-function)' }}>validate</span>(
+              <span style={{ color: 'var(--code-string)' }}>'12.345.678-5'</span>){' '}
+              <span style={{ color: 'var(--code-comment)' }}>// → true</span>
+              {'\n\n'}
+              <span style={{ color: 'var(--code-gray)' }}>// Format with dots and hyphen</span>
+              {'\n'}
+              <span style={{ color: 'var(--code-function)' }}>format</span>(
+              <span style={{ color: 'var(--code-string)' }}>'123456785'</span>){' '}
+              <span style={{ color: 'var(--code-gray)' }}>// → '12.345.678-5'</span>
+              {'\n\n'}
+              <span style={{ color: 'var(--code-gray)' }}>// Incremental formatting</span>
+              {'\n'}
+              <span style={{ color: 'var(--code-function)' }}>format</span>(
+              <span style={{ color: 'var(--code-string)' }}>'1234'</span>, {'{ '}
+              <span style={{ color: 'var(--code-identifier)' }}>incremental</span>:{' '}
+              <span style={{ color: 'var(--code-boolean)' }}>true</span>
+              {' }'}){'\n'}
+              <span style={{ color: 'var(--code-gray)' }}>// → '1.234'</span>
+            </CodeBlock>
           </div>
         </div>
 
@@ -145,13 +156,13 @@ format('1234', { incremental: true })
             Ready to get started?
           </h2>
           <div style={{
-            background: 'rgba(255,255,255,0.05)',
-            border: '1px solid rgba(255,255,255,0.1)',
+            background: 'var(--code-bg)',
+            border: '1px solid rgba(255,255,255,0.2)',
             borderRadius: '16px',
             padding: '32px',
             marginBottom: '32px'
           }}>
-            <code style={{ fontSize: '24px', fontFamily: 'monospace' }}>npm install rut.ts</code>
+            <CodeBlock><span style={{ color: 'var(--code-function)', fontSize: '24px' }}>npm</span><span style={{ color: 'var(--code-string)', fontSize: '24px' }}> install rut.ts</span></CodeBlock>
           </div>
           <Link
             href="/docs"


### PR DESCRIPTION
Summary
- Add reusable CodeBlock component with GitHub Dark theme for the landing page
- Extract code styling to CSS variables for consistency with MDX documentation pages
- Improve hero section visual appeal

Why
The landing page hero had inline code styles that didn't match the MDX documentation theme. This PR:
- Unifies code appearance between hero and documentation pages
- Makes styling maintainable through CSS variables
- Improves visual consistency across the entire site

I hope you like this small contribution. It’s just a minor tweak while I’m getting to know the project, and I’m excited to keep contributing and improving things together!

![Diseño sin título](https://github.com/user-attachments/assets/5fa7fef3-101c-4f9d-96bd-c2ef7c3c1992)
