### PR TITLE
feat(docs): add copy functionality to code blocks in MDX and hero page

### DIFF
--- a/docs/src/app/components/CodeBlocks.jsx
+++ b/docs/src/app/components/CodeBlocks.jsx
@@ -14,6 +14,8 @@ export function CodeBlock({ children, ...props }) {
         lineHeight: '1.5',
         fontFamily: 'Consolas, Monaco, "Courier New", monospace',
         fontSize: props.style?.fontSize || '16px',
+        padding: '32px',
+        border: '1px solid rgba(255,255,255,0.2)',
       }}
     >
       <code {...props}>{children}</code>

--- a/docs/src/app/components/CopyButton.jsx
+++ b/docs/src/app/components/CopyButton.jsx
@@ -1,0 +1,91 @@
+'use client'
+
+import { useState } from 'react'
+
+const CopyIcon = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="14"
+    height="14"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <rect width="14" height="14" x="8" y="8" rx="2" ry="2" />
+    <path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2" />
+  </svg>
+)
+
+const CheckIcon = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="14"
+    height="14"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M20 6 9 17l-5-5" />
+  </svg>
+)
+
+export function CopyButton({ code }) {
+  const [copied, setCopied] = useState(false)
+
+  const handleCopy = async () => {
+    if (!code) return
+    try {
+      await navigator.clipboard.writeText(code)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch (err) {
+      console.error('Failed to copy:', err)
+    }
+  }
+
+  return (
+    <button
+      onClick={handleCopy}
+      disabled={!code}
+      className="copy-button"
+      style={{
+        position: 'absolute',
+        top: '12px',
+        right: '12px',
+        padding: '6px 8px',
+        background: 'rgba(255,255,255,0.05)',
+        border: '1px solid rgba(255,255,255,0.1)',
+        borderRadius: '6px',
+        cursor: code ? 'pointer' : 'not-allowed',
+        transition: 'all 0.15s ease',
+        display: 'flex',
+        alignItems: 'center',
+        gap: '4px',
+        fontSize: '12px',
+        color:'rgba(255,255,255,0.5)',
+        fontFamily: 'system-ui, -apple-system, sans-serif',
+        zIndex: 10,
+      }}
+      onMouseEnter={(e) => {
+        if (code && !copied) {
+          e.currentTarget.style.background = 'rgba(255,255,255,0.1)'
+          e.currentTarget.style.color = '#fff'
+        }
+      }}
+      onMouseLeave={(e) => {
+        if (!copied) {
+          e.currentTarget.style.background = 'rgba(255,255,255,0.05)'
+          e.currentTarget.style.color = 'rgba(255,255,255,0.5)'
+        }
+      }}
+    >
+      {copied ? <CheckIcon /> : <CopyIcon />}
+    </button>
+  )
+}

--- a/docs/src/app/constants/hero-page.ts
+++ b/docs/src/app/constants/hero-page.ts
@@ -1,0 +1,9 @@
+export const installCode = `npm install rut.ts`
+export const exampleCode = `import { validate, format } from 'rut.ts'
+// Validate any RUT format
+validate('12.345.678-5') // → true
+// Format with dots and hyphen
+format('123456785') // → '12.345.678-5'
+// Incremental formatting
+format('1234', { incremental: true })
+// → '1.234'`

--- a/docs/src/app/globals.css
+++ b/docs/src/app/globals.css
@@ -38,3 +38,13 @@ body:not(:has([class*="nx-"])) {
     )
     rgb(var(--background-start-rgb));
 }
+
+/* CopyButton visibility: show only on hover over CodeBlock */
+pre:hover .copy-button {
+  opacity: 1 !important;
+}
+
+.copy-button {
+  opacity: 0;
+  transition: opacity 0.2s ease;
+}

--- a/docs/src/app/page.jsx
+++ b/docs/src/app/page.jsx
@@ -1,5 +1,7 @@
 import Link from 'next/link'
 import { CodeBlock } from './components/CodeBlocks'
+import { CopyButton } from './components/CopyButton'
+import { exampleCode, installCode } from './constants/hero-page'
 
 export default function HomePage() {
   return (
@@ -86,11 +88,11 @@ export default function HomePage() {
             margin: '0 auto',
             background: 'var(--code-bg)',
             borderRadius: '16px',
-            border: '1px solid rgba(255,255,255,0.2)',
-            padding: '32px',
             textAlign: 'left',
-          }}>
+            position: 'relative',
+          }}>     
             <CodeBlock>
+              <CopyButton code={exampleCode}/>
               <span style={{ color: 'var(--code-keyword)' }}>import</span> {'{ '}
               <span style={{ color: 'var(--code-identifier)' }}>validate</span>,{' '}
               <span style={{ color: 'var(--code-identifier)' }}>format</span>
@@ -157,12 +159,12 @@ export default function HomePage() {
           </h2>
           <div style={{
             background: 'var(--code-bg)',
-            border: '1px solid rgba(255,255,255,0.2)',
             borderRadius: '16px',
-            padding: '32px',
-            marginBottom: '32px'
+            marginBottom: '32px',
+            position: 'relative',
           }}>
-            <CodeBlock><span style={{ color: 'var(--code-function)', fontSize: '24px' }}>npm</span><span style={{ color: 'var(--code-string)', fontSize: '24px' }}> install rut.ts</span></CodeBlock>
+            
+            <CodeBlock><CopyButton code={installCode}/><span style={{ color: 'var(--code-function)', fontSize: '24px' }}>npm</span><span style={{ color: 'var(--code-string)', fontSize: '24px' }}> install rut.ts</span></CodeBlock>
           </div>
           <Link
             href="/docs"

--- a/docs/src/content/api-reference.mdx
+++ b/docs/src/content/api-reference.mdx
@@ -30,7 +30,7 @@ Complete API documentation for all rut.ts functions.
 
 ## TypeScript Types
 
-```typescript
+```typescript copy
 import type { 
   DecomposedRut,
   FormatOptions,
@@ -42,7 +42,7 @@ import type {
 
 ### DecomposedRut
 
-```typescript
+```typescript copy
 type DecomposedRut = {
   body: string      // RUT body (7-8 digits)
   verifier: string  // Verifier digit ('0'-'9' or 'K')
@@ -51,7 +51,7 @@ type DecomposedRut = {
 
 ### FormatOptions
 
-```typescript
+```typescript copy
 type FormatOptions = {
   incremental?: boolean   // Progressive formatting mode
   dots?: boolean          // Include dot separators (default: true)
@@ -61,7 +61,7 @@ type FormatOptions = {
 
 ### SafeOptions
 
-```typescript
+```typescript copy
 type SafeOptions = {
   throwOnError?: boolean  // Return null on error (default: true)
 }
@@ -69,7 +69,7 @@ type SafeOptions = {
 
 ### ValidateOptions
 
-```typescript
+```typescript copy
 type ValidateOptions = {
   strict?: boolean  // Reject suspicious patterns (default: false)
 }
@@ -77,7 +77,7 @@ type ValidateOptions = {
 
 ### VerifierDigit
 
-```typescript
+```typescript copy
 type VerifierDigit = 
   | '0' | '1' | '2' | '3' | '4' 
   | '5' | '6' | '7' | '8' | '9' 
@@ -102,7 +102,7 @@ type VerifierDigit =
 
 ### Validation Pipeline
 
-```typescript
+```typescript copy
 import { isRutLike, validate, clean } from 'rut.ts'
 
 function validateRutPipeline(input: unknown) {
@@ -119,7 +119,7 @@ function validateRutPipeline(input: unknown) {
 
 ### Safe Processing
 
-```typescript
+```typescript copy
 import { clean, decompose, calculateVerifier } from 'rut.ts'
 
 function safeProcessRut(input: string) {
@@ -135,7 +135,7 @@ function safeProcessRut(input: string) {
 
 ### Format + Validate
 
-```typescript
+```typescript copy
 import { format, validate } from 'rut.ts'
 
 function formatAndValidate(input: string) {

--- a/docs/src/content/contributing.mdx
+++ b/docs/src/content/contributing.mdx
@@ -74,7 +74,7 @@ npm run build
 
 ### Example Test Structure
 
-```typescript
+```typescript copy
 describe('myFunction', () => {
   describe('basic functionality', () => {
     test('handles valid input', () => {

--- a/docs/src/content/examples/basic-usage.mdx
+++ b/docs/src/content/examples/basic-usage.mdx
@@ -4,7 +4,7 @@ Common patterns and examples for working with rut.ts.
 
 ## Simple Validation
 
-```typescript
+```typescript copy
 import { validate } from 'rut.ts'
 
 // Check if valid
@@ -17,7 +17,7 @@ if (validate('12.345.678-5')) {
 
 ## Format and Display
 
-```typescript
+```typescript copy
 import { format } from 'rut.ts'
 
 // User enters: "123456785"
@@ -30,7 +30,7 @@ document.getElementById('rut').textContent = formatted
 
 ## Clean Before Storage
 
-```typescript
+```typescript copy
 import { clean, validate } from 'rut.ts'
 
 function saveRut(userInput: string) {
@@ -52,7 +52,7 @@ function saveRut(userInput: string) {
 
 ## Generate Test Data
 
-```typescript
+```typescript copy
 import { generate } from 'rut.ts'
 
 // Generate 10 test users
@@ -72,7 +72,7 @@ console.log(testUsers)
 
 ## Decompose for Database
 
-```typescript
+```typescript copy
 import { decompose } from 'rut.ts'
 
 function storeRut(rut: string) {
@@ -89,7 +89,7 @@ function storeRut(rut: string) {
 
 ## Verify Correctness
 
-```typescript
+```typescript copy
 import { decompose, calculateVerifier } from 'rut.ts'
 
 function isRutCorrect(rut: string): boolean {
@@ -104,7 +104,7 @@ console.log(isRutCorrect('12.345.678-0'))  // false
 
 ## Type Guards
 
-```typescript
+```typescript copy
 import { validate, isRutLike } from 'rut.ts'
 
 function isValidRut(value: unknown): value is string {
@@ -122,7 +122,7 @@ function processInput(input: unknown) {
 
 ## Safe Error Handling
 
-```typescript
+```typescript copy
 import { clean, format, decompose } from 'rut.ts'
 
 function processUserRut(input: string) {

--- a/docs/src/content/examples/error-handling.mdx
+++ b/docs/src/content/examples/error-handling.mdx
@@ -8,7 +8,7 @@ All functions support `throwOnError: false` to return `null` instead of throwing
 
 ### Without Safe Mode (Default)
 
-```typescript
+```typescript copy
 import { clean, format, decompose } from 'rut.ts'
 
 try {
@@ -32,7 +32,7 @@ try {
 
 ### With Safe Mode
 
-```typescript
+```typescript copy
 import { clean, format, decompose } from 'rut.ts'
 
 const cleaned = clean('invalid', { throwOnError: false })
@@ -49,7 +49,7 @@ console.log(parts)  // null
 
 ### Form Validation
 
-```typescript
+```typescript copy
 import { validate, format, clean } from 'rut.ts'
 
 function validateRutInput(input: string) {
@@ -89,7 +89,7 @@ function validateRutInput(input: string) {
 
 ### API Route Handler
 
-```typescript
+```typescript copy
 import { validate, clean } from 'rut.ts'
 
 export async function POST(request: Request) {
@@ -119,7 +119,7 @@ export async function POST(request: Request) {
 
 ### Chain Operations Safely
 
-```typescript
+```typescript copy
 import { clean, decompose, calculateVerifier } from 'rut.ts'
 
 function processRutSafely(input: string) {
@@ -157,7 +157,7 @@ function processRutSafely(input: string) {
 
 ### Custom Error Messages
 
-```typescript
+```typescript copy
 import { validate, clean } from 'rut.ts'
 
 function getRutError(rut: string): string | null {
@@ -190,7 +190,7 @@ if (error) {
 
 ### Localized Errors
 
-```typescript
+```typescript copy
 import { validate } from 'rut.ts'
 
 const errorMessages = {
@@ -219,7 +219,7 @@ function validateWithLocale(rut: string, locale: 'en' | 'es' = 'es') {
 
 ## TypeScript Type Guards
 
-```typescript
+```typescript copy
 import { validate, clean } from 'rut.ts'
 
 type Result<T> = 

--- a/docs/src/content/examples/form-integration.mdx
+++ b/docs/src/content/examples/form-integration.mdx
@@ -44,7 +44,7 @@ How to integrate rut.ts with form libraries and validation.
 
 ## React Hook Form
 
-```typescript
+```typescript copy
 import { useForm } from 'react-hook-form'
 import { validate } from 'rut.ts'
 
@@ -80,7 +80,7 @@ function MyForm() {
 
 ## Zod Schema Validation
 
-```typescript
+```typescript copy
 import { z } from 'zod'
 import { validate } from 'rut.ts'
 
@@ -107,7 +107,7 @@ if (result.success) {
 
 ## Formik
 
-```typescript
+```typescript copy
 import { Formik, Form, Field, ErrorMessage } from 'formik'
 import { validate, format } from 'rut.ts'
 
@@ -149,7 +149,7 @@ function MyForm() {
 
 ## Next.js Server Actions
 
-```typescript
+```typescript copy
 'use server'
 
 import { validate, clean } from 'rut.ts'
@@ -184,7 +184,7 @@ export async function createUser(formData: FormData) {
 
 ## Yup Schema
 
-```typescript
+```typescript copy
 import * as yup from 'yup'
 import { validate } from 'rut.ts'
 
@@ -208,7 +208,7 @@ try {
 
 ## Custom Hook (React)
 
-```typescript
+```typescript copy
 import { useState, useCallback } from 'react'
 import { format, validate } from 'rut.ts'
 

--- a/docs/src/content/examples/index.mdx
+++ b/docs/src/content/examples/index.mdx
@@ -17,7 +17,7 @@ import { Cards } from 'nextra/components'
 
 ### Validation + Formatting
 
-```typescript
+```typescript copy
 import { validate, format } from 'rut.ts'
 
 function processRut(input: string) {
@@ -30,7 +30,7 @@ function processRut(input: string) {
 
 ### Clean + Validate
 
-```typescript
+```typescript copy
 import { clean, validate } from 'rut.ts'
 
 function normalizeAndValidate(input: string) {
@@ -41,7 +41,7 @@ function normalizeAndValidate(input: string) {
 
 ### Decompose + Calculate
 
-```typescript
+```typescript copy
 import { decompose, calculateVerifier } from 'rut.ts'
 
 function verifyRut(rut: string) {

--- a/docs/src/content/examples/react-example.mdx
+++ b/docs/src/content/examples/react-example.mdx
@@ -4,7 +4,7 @@ Complete React examples with rut.ts.
 
 ## Simple RUT Input Component
 
-```typescript
+```typescript copy
 import { useState } from 'react'
 import { format, validate } from 'rut.ts'
 
@@ -37,7 +37,7 @@ export function RutInput() {
 
 ## Controlled Component with Validation
 
-```typescript
+```typescript copy
 import { useState, useEffect } from 'react'
 import { format, validate, clean } from 'rut.ts'
 
@@ -105,7 +105,7 @@ export function RutInput({
 
 ## Form with Multiple Fields
 
-```typescript
+```typescript copy
 import { useState } from 'react'
 import { validate, clean, format } from 'rut.ts'
 
@@ -189,7 +189,7 @@ export function UserRegistration() {
 
 ## Display Formatted RUT
 
-```typescript
+```typescript copy
 import { format } from 'rut.ts'
 
 interface RutDisplayProps {
@@ -217,7 +217,7 @@ export function RutDisplay({ rut, withDots = true }: RutDisplayProps) {
 
 ## Searchable RUT Table
 
-```typescript
+```typescript copy
 import { useState, useMemo } from 'react'
 import { clean, format, isRutLike } from 'rut.ts'
 

--- a/docs/src/content/features/calculate-verifier.mdx
+++ b/docs/src/content/features/calculate-verifier.mdx
@@ -4,7 +4,7 @@ Calculates the verifier digit for a given RUT body using the Modulo 11 algorithm
 
 ## Basic Usage
 
-```typescript
+```typescript copy
 import { calculateVerifier } from 'rut.ts'
 
 calculateVerifier('12345678')  // '5'
@@ -13,7 +13,7 @@ calculateVerifier('24657622')  // 'K'
 
 ## Type Signature
 
-```typescript
+```typescript copy
 function calculateVerifier(rutBody: string): VerifierDigit
 function calculateVerifier(rutBody: string, options: { throwOnError: false }): VerifierDigit | null
 function calculateVerifier(rutBody: string, options: { throwOnError: true }): VerifierDigit
@@ -49,7 +49,7 @@ The function implements the **Modulo 11 algorithm**:
 
 ### Basic Calculation
 
-```typescript
+```typescript copy
 import { calculateVerifier } from 'rut.ts'
 
 // Numeric verifiers
@@ -64,7 +64,7 @@ calculateVerifier('14625621')  // 'K'
 
 ### Building a Complete RUT
 
-```typescript
+```typescript copy
 import { calculateVerifier, format } from 'rut.ts'
 
 const body = '12345678'
@@ -76,7 +76,7 @@ console.log(completeRut)  // '12.345.678-5'
 
 ### Safe Mode
 
-```typescript
+```typescript copy
 import { calculateVerifier } from 'rut.ts'
 
 // Without safe mode (throws)
@@ -103,7 +103,7 @@ const handleBodyInput = (body: string) => {
 
 ### Input Flexibility
 
-```typescript
+```typescript copy
 import { calculateVerifier } from 'rut.ts'
 
 // Accepts formatted input (dots/hyphens removed)

--- a/docs/src/content/features/clean.mdx
+++ b/docs/src/content/features/clean.mdx
@@ -4,7 +4,7 @@ Removes extraneous characters and leading zeros from RUT strings, returning a no
 
 ## Basic Usage
 
-```typescript
+```typescript copy
 import { clean } from 'rut.ts'
 
 clean('12.345.678-5')  // '123456785'
@@ -14,7 +14,7 @@ clean('00012345678K')  // '12345678K'
 
 ## Type Signature
 
-```typescript
+```typescript copy
 function clean(rut: string): string
 function clean(rut: string, options: { throwOnError: false }): string | null
 function clean(rut: string, options: { throwOnError: true }): string
@@ -40,7 +40,7 @@ type SafeOptions = {
 
 ### Basic Cleaning
 
-```typescript
+```typescript copy
 import { clean } from 'rut.ts'
 
 // Remove dots and hyphens
@@ -58,7 +58,7 @@ clean('12345678k')  // '12345678K'
 
 ### Safe Mode
 
-```typescript
+```typescript copy
 import { clean } from 'rut.ts'
 
 // Without safe mode (throws)
@@ -87,7 +87,7 @@ const handleInput = (value: string) => {
 
 ### What Gets Cleaned
 
-```typescript
+```typescript copy
 import { clean } from 'rut.ts'
 
 // Multiple hyphens

--- a/docs/src/content/features/decompose.mdx
+++ b/docs/src/content/features/decompose.mdx
@@ -4,7 +4,7 @@ Splits a RUT into its body and verifier digit components.
 
 ## Basic Usage
 
-```typescript
+```typescript copy
 import { decompose } from 'rut.ts'
 
 const { body, verifier } = decompose('12.345.678-5')
@@ -14,7 +14,7 @@ console.log(verifier)  // '5'
 
 ## Type Signature
 
-```typescript
+```typescript copy
 function decompose(rut: string): DecomposedRut
 function decompose(rut: string, options: { throwOnError: false }): DecomposedRut | null
 function decompose(rut: string, options: { throwOnError: true }): DecomposedRut
@@ -41,7 +41,7 @@ Returns `DecomposedRut` object or `null`:
 
 ### Basic Decomposition
 
-```typescript
+```typescript copy
 import { decompose } from 'rut.ts'
 
 // Standard format
@@ -62,7 +62,7 @@ console.log(rut3.verifier)  // 'K'
 
 ### Safe Mode
 
-```typescript
+```typescript copy
 import { decompose } from 'rut.ts'
 
 // Without safe mode (throws)
@@ -93,7 +93,7 @@ const processRut = (input: string) => {
 
 ### Destructuring
 
-```typescript
+```typescript copy
 import { decompose } from 'rut.ts'
 
 // Direct destructuring
@@ -111,7 +111,7 @@ if (parts) {
 
 ### Store Body and Verifier Separately
 
-```typescript
+```typescript copy
 import { decompose } from 'rut.ts'
 
 const { body, verifier } = decompose('12.345.678-5')
@@ -124,7 +124,7 @@ await db.users.create({
 
 ### Compare RUT Bodies
 
-```typescript
+```typescript copy
 import { decompose } from 'rut.ts'
 
 const rut1 = decompose('12.345.678-5')
@@ -137,7 +137,7 @@ if (rut1.body === rut2.body) {
 
 ### Extract for Processing
 
-```typescript
+```typescript copy
 import { decompose, calculateVerifier } from 'rut.ts'
 
 // Verify RUT by recalculating verifier
@@ -151,7 +151,7 @@ if (calculated === verifier) {
 
 ### Partial Matching in Database Queries
 
-```typescript
+```typescript copy
 import { decompose } from 'rut.ts'
 
 const { body } = decompose('12.345.678-5')

--- a/docs/src/content/features/format.mdx
+++ b/docs/src/content/features/format.mdx
@@ -4,7 +4,7 @@ Converts RUT strings into a standardized format with dots and hyphens.
 
 ## Basic Usage
 
-```typescript
+```typescript copy
 import { format } from 'rut.ts'
 
 format('123456785')                  // '12.345.678-5'
@@ -13,7 +13,7 @@ format('123456785', { dots: false }) // '12345678-5'
 
 ## Type Signature
 
-```typescript
+```typescript copy
 function format(rut: string, options?: FormatOptions): string
 function format(rut: string, options: FormatOptions & { throwOnError: false }): string | null
 function format(rut: string, options: FormatOptions & { throwOnError: true }): string
@@ -43,7 +43,7 @@ type FormatOptions = {
 
 ### Standard Formatting
 
-```typescript
+```typescript copy
 import { format } from 'rut.ts'
 
 // With dots (default)
@@ -64,7 +64,7 @@ format('  123456785  ')  // '12.345.678-5'
 
 Perfect for real-time formatting as users type:
 
-```typescript
+```typescript copy
 import { format } from 'rut.ts'
 
 // Progressive formatting
@@ -87,7 +87,7 @@ import { Callout } from 'nextra/components'
 
 ### React Example
 
-```typescript
+```typescript copy
 import { format, validate } from 'rut.ts'
 import { useState } from 'react'
 
@@ -114,7 +114,7 @@ function RutInput() {
 
 ### Safe Mode
 
-```typescript
+```typescript copy
 import { format } from 'rut.ts'
 
 // Without safe mode (throws)
@@ -151,7 +151,7 @@ format('invalid', {
 
 ## Edge Cases
 
-```typescript
+```typescript copy
 import { format } from 'rut.ts'
 
 // Empty string

--- a/docs/src/content/features/generate.mdx
+++ b/docs/src/content/features/generate.mdx
@@ -4,7 +4,7 @@ Generates random valid RUT numbers for testing and development purposes.
 
 ## Basic Usage
 
-```typescript
+```typescript copy
 import { generate } from 'rut.ts'
 
 const randomRut = generate()
@@ -13,7 +13,7 @@ console.log(randomRut)  // '18.972.631-7'
 
 ## Type Signature
 
-```typescript
+```typescript copy
 function generate(): string
 ```
 
@@ -33,7 +33,7 @@ Returns a `string` containing:
 
 ### Generate Single RUT
 
-```typescript
+```typescript copy
 import { generate } from 'rut.ts'
 
 const rut = generate()
@@ -42,7 +42,7 @@ console.log(rut)  // e.g., '45.123.789-2'
 
 ### Generate Multiple RUTs
 
-```typescript
+```typescript copy
 import { generate } from 'rut.ts'
 
 const ruts = Array.from({ length: 10 }, () => generate())
@@ -52,7 +52,7 @@ console.log(ruts)
 
 ### Generate for Testing
 
-```typescript
+```typescript copy
 import { generate, validate } from 'rut.ts'
 
 // Generate test data
@@ -66,7 +66,7 @@ testRuts.forEach(rut => {
 
 ### Seed Test Database
 
-```typescript
+```typescript copy
 import { generate, decompose } from 'rut.ts'
 
 // Create test users with valid RUTs
@@ -120,7 +120,7 @@ XX.XXX.XXX-Y
 
 ## Examples in Testing
 
-```typescript
+```typescript copy
 import { generate, validate } from 'rut.ts'
 
 describe('RUT validation', () => {

--- a/docs/src/content/features/get-body.mdx
+++ b/docs/src/content/features/get-body.mdx
@@ -4,7 +4,7 @@ Extracts just the body (without verifier digit) from a RUT string.
 
 ## Basic Usage
 
-```typescript
+```typescript copy
 import { getBody } from 'rut.ts'
 
 getBody('12.345.678-5')  // '12345678'
@@ -13,7 +13,7 @@ getBody('9068826K')      // '9068826'
 
 ## Type Signature
 
-```typescript
+```typescript copy
 function getBody(rut: string): string
 function getBody(rut: string, options: { throwOnError: false }): string | null
 function getBody(rut: string, options: { throwOnError: true }): string
@@ -34,7 +34,7 @@ function getBody(rut: string, options: { throwOnError: true }): string
 
 ### Basic Extraction
 
-```typescript
+```typescript copy
 import { getBody } from 'rut.ts'
 
 getBody('12.345.678-5')    // '12345678'
@@ -44,7 +44,7 @@ getBody('9.068.826-K')     // '9068826'
 
 ### Safe Mode
 
-```typescript
+```typescript copy
 import { getBody } from 'rut.ts'
 
 const body = getBody('invalid', { throwOnError: false })

--- a/docs/src/content/features/get-verifier.mdx
+++ b/docs/src/content/features/get-verifier.mdx
@@ -4,7 +4,7 @@ Extracts just the verifier digit from a RUT string.
 
 ## Basic Usage
 
-```typescript
+```typescript copy
 import { getVerifier } from 'rut.ts'
 
 getVerifier('12.345.678-5')  // '5'
@@ -13,7 +13,7 @@ getVerifier('9068826K')      // 'K'
 
 ## Type Signature
 
-```typescript
+```typescript copy
 function getVerifier(rut: string): VerifierDigit
 function getVerifier(rut: string, options: { throwOnError: false }): VerifierDigit | null
 function getVerifier(rut: string, options: { throwOnError: true }): VerifierDigit
@@ -37,7 +37,7 @@ Returns `VerifierDigit` or `null`:
 
 ### Basic Extraction
 
-```typescript
+```typescript copy
 import { getVerifier } from 'rut.ts'
 
 getVerifier('12.345.678-5')    // '5'
@@ -48,7 +48,7 @@ getVerifier('9068826k')        // 'K' (converted to uppercase)
 
 ### Safe Mode
 
-```typescript
+```typescript copy
 import { getVerifier } from 'rut.ts'
 
 const verifier = getVerifier('invalid', { throwOnError: false })
@@ -57,7 +57,7 @@ console.log(verifier)  // null
 
 ### Verify Correctness
 
-```typescript
+```typescript copy
 import { getVerifier, calculateVerifier, getBody } from 'rut.ts'
 
 const rut = '12.345.678-5'

--- a/docs/src/content/features/is-rut-like.mdx
+++ b/docs/src/content/features/is-rut-like.mdx
@@ -4,7 +4,7 @@ Quick format check to determine if a string looks like a RUT, without validating
 
 ## Basic Usage
 
-```typescript
+```typescript copy
 import { isRutLike } from 'rut.ts'
 
 isRutLike('12.345.678-9')  // true
@@ -13,7 +13,7 @@ isRutLike('not-a-rut')     // false
 
 ## Type Signature
 
-```typescript
+```typescript copy
 function isRutLike(rut: string): boolean
 ```
 
@@ -31,7 +31,7 @@ Returns `boolean`:
 
 ### Valid Formats
 
-```typescript
+```typescript copy
 import { isRutLike } from 'rut.ts'
 
 // All RUT-like formats
@@ -44,7 +44,7 @@ isRutLike('09.068.826-K')   // true (leading zeros)
 
 ### Invalid Formats
 
-```typescript
+```typescript copy
 import { isRutLike } from 'rut.ts'
 
 isRutLike('abcdefgh')      // false (letters)
@@ -63,7 +63,7 @@ import { Callout } from 'nextra/components'
   Use **`validate()`** for full validation including verifier digit check.
 </Callout>
 
-```typescript
+```typescript copy
 import { isRutLike, validate } from 'rut.ts'
 
 const rut = '12.345.678-0' // Wrong verifier (should be 5)
@@ -76,7 +76,7 @@ validate(rut)    // false ❌ (verifier is wrong)
 
 ### Early Form Validation
 
-```typescript
+```typescript copy
 import { isRutLike } from 'rut.ts'
 
 function handleInput(value: string) {
@@ -94,7 +94,7 @@ function handleInput(value: string) {
 
 ### Filter Lists
 
-```typescript
+```typescript copy
 import { isRutLike } from 'rut.ts'
 
 const inputs = [
@@ -113,7 +113,7 @@ console.log(potentialRuts)
 
 ### Pre-validation Check
 
-```typescript
+```typescript copy
 import { isRutLike, validate } from 'rut.ts'
 
 function validateRut(input: unknown): boolean {

--- a/docs/src/content/features/validate.mdx
+++ b/docs/src/content/features/validate.mdx
@@ -4,7 +4,7 @@ Validates a given RUT string, checking both format and verifier digit.
 
 ## Basic Usage
 
-```typescript
+```typescript copy
 import { validate } from 'rut.ts'
 
 validate('12.345.678-5') // true
@@ -14,7 +14,7 @@ validate('invalid')      // false
 
 ## Type Signature
 
-```typescript
+```typescript copy
 function validate(rut: unknown, options?: ValidateOptions): boolean
 
 type ValidateOptions = {
@@ -38,7 +38,7 @@ Returns `boolean`:
 
 ### Basic Validation
 
-```typescript
+```typescript copy
 import { validate } from 'rut.ts'
 
 // Valid RUTs
@@ -59,7 +59,7 @@ validate(123)              // false
 
 Strict mode rejects suspicious patterns like repeated digits:
 
-```typescript
+```typescript copy
 import { validate } from 'rut.ts'
 
 // Suspicious RUTs (technically valid, but unlikely to be real)
@@ -76,7 +76,7 @@ validate('22.222.222-2')  // true
 
 The function accepts `unknown` input for better type safety:
 
-```typescript
+```typescript copy
 import { validate } from 'rut.ts'
 
 function processUserInput(input: unknown) {

--- a/docs/src/content/index.mdx
+++ b/docs/src/content/index.mdx
@@ -29,17 +29,17 @@ The verifier digit is calculated using the [Modulo 11 algorithm](https://en.wiki
 
 <Tabs items={['npm', 'pnpm', 'bun']}>
   <Tabs.Tab>
-    ```bash
+    ```bash copy
     npm install rut.ts
     ```
   </Tabs.Tab>
   <Tabs.Tab>
-    ```bash
+    ```bash copy
     pnpm install rut.ts
     ```
   </Tabs.Tab>
   <Tabs.Tab>
-    ```bash
+    ```bash copy
     bun add rut.ts
     ```
   </Tabs.Tab>
@@ -47,7 +47,7 @@ The verifier digit is calculated using the [Modulo 11 algorithm](https://en.wiki
 
 ## Quick Example
 
-```typescript
+```typescript copy
 import { validate, format, clean } from 'rut.ts'
 
 // Validate a RUT

--- a/docs/src/content/testing.mdx
+++ b/docs/src/content/testing.mdx
@@ -102,7 +102,7 @@ npm test -- --coverage
 
 ### validate() Tests
 
-```typescript
+```typescript copy
 describe('validate', () => {
   test('validates correct RUTs', () => {
     expect(validate('12.345.678-5')).toBe(true)
@@ -122,7 +122,7 @@ describe('validate', () => {
 
 ### format() Tests
 
-```typescript
+```typescript copy
 describe('format', () => {
   test('formats with dots', () => {
     expect(format('123456785')).toBe('12.345.678-5')
@@ -141,7 +141,7 @@ describe('format', () => {
 
 ### Safe Mode Tests
 
-```typescript
+```typescript copy
 describe('safe mode', () => {
   test('returns null instead of throwing', () => {
     expect(clean('invalid', { throwOnError: false })).toBeNull()


### PR DESCRIPTION
Added copy button to all code blocks for improved user experience.
- Added copy button to all MDX documentation files with the `copy` attribute
- Created reusable CopyButton component for the hero page with SVG icons
- Updated hero page to include copy functionality for code examples
<img width="867" height="166" alt="Captura de pantalla 2026-04-02 183921" src="https://github.com/user-attachments/assets/c3b46e98-11fe-43f7-b489-73e9bcb7610a" />
<img width="728" height="355" alt="Captura de pantalla 2026-04-02 183850" src="https://github.com/user-attachments/assets/02ea02c4-1d28-4ced-a933-f11c0f758cbf" />
