### PR TITLE
feat!: harden RUT validation for production identity use (v4.0.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,55 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [canary]
+
+# Cancel superseded runs on the same ref (e.g. quick successive pushes to a PR).
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: test (node ${{ matrix.node }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # The library uses Web Crypto (`globalThis.crypto`) in generate(),
+        # available since Node 19. Test the active LTS lines.
+        node: [20, 22]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+          cache: npm
+
+      # NOTE: we intentionally use `npm install`, not `npm ci`.
+      # The committed package-lock.json is out of sync with package.json
+      # (devDependencies were bumped — eslint 8->9, jest 29->30, typescript
+      # 5.4->5.9, ... — without regenerating the lock). This pre-existing drift
+      # also breaks `npm ci` and `npm run lint`. Once the lockfile is
+      # regenerated (`npm install` committed) this should be restored to
+      # `npm ci` for reproducible installs.
+      - name: Install dependencies
+        run: npm install --no-audit --no-fund
+
+      - name: Unit tests
+        run: npm test
+
+      - name: Build (tsc ESM + CJS + terser)
+        run: npm run build
+
+      # Differential guard: 3.4.0 vs current validate() over a stratified
+      # corpus. Fails if any non-documented behavior change is introduced.
+      - name: Differential (behavior regression guard)
+        run: npm run test:differential
+
+  # `npm run lint` is intentionally NOT a job yet: ESLint 9 requires an
+  # `eslint.config.*` flat config but the repo still ships `.eslintrc`, and the
+  # lockfile drift above compounds it. Add a lint job in the follow-up that
+  # migrates the ESLint config and regenerates the lockfile.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,140 @@
+# Changelog
+
+All notable changes to **rut.ts** are documented in this file.
+
+This changelog starts at **v4.0.0**. Releases `3.4.0` and earlier predate this
+file and were not formally tracked here. From this version onward, every release
+documents its changes and—when applicable—its breaking changes.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [4.0.0] - 2026-05-17
+
+A **major, breaking** release that hardens the library for high-volume
+RUT/RUN **identity validation in production**. The Modulo 11 algorithm itself
+was already correct; this release hardens the input perimeter and tightens the
+"clean / format / validate" contract. Upgrading from `3.x` requires reading the
+**Breaking changes** section below.
+
+### Why this is a major release
+
+`3.x` accepted ambiguous input shapes, "repaired" RUTs with an incorrect
+verifier digit when formatting, echoed the raw input into error messages, and
+had a regex that was vulnerable to ReDoS on adversarial input. Fixing these
+correctly changes observable behavior for some inputs, so per SemVer this is a
+major version bump even though several items are security fixes.
+
+### Security
+
+- **ReDoS / unbounded input.** `validate()` and `isRutLike()` previously ran an
+  ambiguous regex (`/^0*(\d{1,3}(\.?\d{3})*)-?([\dkK])$/`) **before any length
+  check**. Adversarial input exhibited catastrophic backtracking
+  (`"0".repeat(16000) + "x"` ≈ **353 ms**; growing super-linearly), and
+  `isRutLike("1".repeat(50000))` returned `true`. Inputs are now length-capped
+  (`MAX_RUT_INPUT_LENGTH = 64`) **before** any regex work, and matched against
+  bounded, non-ambiguous shape patterns (compact / compact-with-hyphen /
+  canonical-dotted). Adversarial input is now rejected in well under 1 ms.
+- **`strict` bypass with uppercase `K`.**
+  `validate('8.888.888-K', { strict: true })` incorrectly returned `true`
+  because the suspicious-pattern regex only matched lowercase `k`. Suspicious
+  detection now runs on the normalized, uppercased body and is case-safe.
+- **PII in error messages.** `getInvalidRutError()` echoed the full RUT into the
+  thrown message, which leaked Chilean ID values into logs, traces, and alerts.
+  The message is now the constant `Invalid RUT input`.
+
+### Changed (Breaking)
+
+1. **`format()` no longer "repairs" an incorrect verifier digit.** In
+   non-incremental mode it now validates the verifier (Modulo 11) and returns
+   `null` (safe mode) or throws (default). Previously
+   `format('123456789')` returned `'12.345.678-9'` despite a wrong verifier;
+   it now returns `null` / throws. Inputs with an invalid verifier such as
+   `'1234567K'` are likewise rejected.
+2. **`validate()` / `isRutLike()` reject non-canonical dot grouping.** Only
+   three shapes are accepted (optionally with leading zeros and surrounding
+   whitespace; verifier `k`/`K` is case-insensitive):
+   - compact — `123456785`
+   - compact + hyphen — `12345678-5`
+   - canonical dotted — `12.345.678-5`, `1.234.567-4`
+
+   Shapes accepted by `3.x` but **now rejected**: `12.345678-5`,
+   `12345.678-5`, `1.2.3.4.5.6.7.8-5`, internal spaces (`12 345 678 5`), any
+   input longer than 64 characters.
+3. **`validate()` / `isRutLike()` now `trim()` the input.** Surrounding
+   whitespace is tolerated (`'  12.345.678-5  '` → `true`). This is a
+   relaxation but is still a behavior change.
+4. **Generic error messages.** Every thrown error is now exactly
+   `Error: Invalid RUT input`. Any code matching on the previous
+   `String "<rut>" is not valid as a RUT input` text will no longer match.
+5. **`getInvalidRutError` signature changed** from `(rut: string) => string` to
+   `(_rut?: unknown) => string` and always returns the constant message. This
+   helper is part of the exported API.
+6. **Safe mode is now safe for non-string callers.** `clean()`, `format()`,
+   `calculateVerifier()`, `getBody()`, `getVerifier()`, and `decompose()`
+   previously threw a `TypeError` on non-string input (number, `null`,
+   `undefined`, object). They now honor `throwOnError`: returning `null` in
+   safe mode and throwing the generic `Invalid RUT input` error otherwise.
+7. **Incremental `format()` is capped at the maximum RUT length.** Input is
+   bounded to 64 chars before normalization and the significant value is capped
+   to 9 chars. `format('12345678901234', { incremental: true })` changed from
+   `'1.234.567.890.123-4'` to `'12.345.678-9'`. A trailing `K` is preserved
+   only while the value still fits in 9 chars; beyond the cap the first 9
+   digits are kept and the `K` is dropped. Incremental mode is for live-typing
+   display only — final values must still be checked with `validate()`.
+
+### Fixed
+
+- **`generate()` range bug.** The previous range
+  `Math.floor(10000003 + Math.random() * 90000000)` could emit 9-digit bodies
+  that `calculateVerifier()` rejected (producing an occasional throw). The
+  range is now a correct inclusive `10000000–99999999`.
+- **`generate()` could emit repeated-digit placeholders.** It now skips
+  all-same-digit bodies, so generated RUTs also pass `validate(_, { strict:
+  true })`.
+
+### Added
+
+- **CSPRNG-backed `generate()`.** Uses Web Crypto (`crypto.getRandomValues`)
+  with unbiased rejection sampling when available, falling back to
+  `Math.random()` on older runtimes.
+- **Verifier hot-path optimization.** The Modulo 11 sum is computed with a
+  reverse `charCodeAt` loop instead of `split('').reverse().reduce()`,
+  removing two array allocations per call. Measured throughput on the new
+  `validate()`: ~9M validations/second (1M mixed inputs in ~110 ms).
+- **`CHANGELOG.md`** (this file).
+- **`tests/differential.test.ts`** — a reproducible (seeded) differential
+  harness (`npm run test:differential`) that runs the `3.x` and `4.0.0`
+  `validate()` over a large stratified corpus (default 1,000,000 cases) and
+  writes `tests/differential-report.md` listing every input whose result
+  changed, grouped by input shape. Use it to characterize impact on a real
+  dataset before upgrading.
+- New regression tests: bounded/adversarial input, the `strict` uppercase-`K`
+  bypass, non-string safe mode for every helper, `format()` verifier rejection,
+  and the incremental capping / trailing-`K` edge.
+
+### Internal
+
+- Removed a dead length re-check in `parseRutLike()`: after
+  `isBoundedString()` (which caps the raw length at 64) the post-`trim()`
+  `length > MAX_RUT_INPUT_LENGTH` branch was unreachable, since `trim()` can
+  only shrink the string. Only the whitespace-only (`length === 0`) case
+  remains. No behavior change.
+
+### Migration guide (3.x → 4.0.0)
+
+- **Validation gate:** use `validate(input, { strict: true })` as the
+  acceptance check. Do **not** treat the output of `clean()` / `decompose()` as
+  proof of validity — they remain intentionally permissive normalizers.
+- **Non-canonical input:** if your data source emits RUTs in a shape other than
+  the three accepted ones, normalize it first, or run
+  `npm run test:differential` against a representative sample to get the exact
+  list of values whose result changes.
+- **`format()` for display of arbitrary numbers:** if you relied on `format()`
+  to "fix" arbitrary 8–9 digit numbers, note it now requires a correct
+  verifier in non-incremental mode. Use `incremental: true` for
+  display-as-you-type, and `validate()` for acceptance.
+- **Error handling:** stop matching on error message text; switch to
+  `throwOnError: false` and check for `null`.
+
+[4.0.0]: https://github.com/arrowsw/rut.ts/releases/tag/v4.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,11 @@ major version bump even though several items are security fixes.
   (`MAX_RUT_INPUT_LENGTH = 64`) **before** any regex work, and matched against
   bounded, non-ambiguous shape patterns (compact / compact-with-hyphen /
   canonical-dotted). Adversarial input is now rejected in well under 1 ms.
+  The `64` cap is a security bound, **not** a format rule: a real RUT is ~9
+  significant chars (~12 formatted), so the cap never rejects a realistically
+  formatted RUT — it only refuses to *look at* implausibly long strings. It is
+  deliberately set well above any legitimate input yet small enough that the
+  bounded patterns can never receive an attack string.
 - **`strict` bypass with uppercase `K`.**
   `validate('8.888.888-K', { strict: true })` incorrectly returned `true`
   because the suspicious-pattern regex only matched lowercase `k`. Suspicious

--- a/README.md
+++ b/README.md
@@ -130,6 +130,11 @@ Anything else is rejected, **including non-canonical dot grouping** that older
 versions accepted: `12.345678-5`, `12345.678-5`, `1.2.3.4.5.6.7.8-5`,
 internal spaces (`12 345 678 5`), commas, and any input longer than 64 chars.
 
+> The 64-char limit is a **security bound, not a format rule**. A real RUT is
+> ~9 significant characters (~12 formatted), so the cap never rejects a
+> realistically formatted RUT — it only refuses to *process* implausibly long
+> strings, which neutralizes CPU/ReDoS-style abuse before any parsing runs.
+
 > ⚠️ **Migrating a large dataset?** If your upstream emits RUTs in a non-canonical
 > shape, normalize it to one of the three accepted forms **before** calling
 > `validate()`, or run the differential harness against a representative sample

--- a/README.md
+++ b/README.md
@@ -3,7 +3,10 @@
   <h1>Rut.ts: Handle chilean RUT values with ease using TypeScript.</h1>
 </div>
 
-![Open Bundle](https://deno.bundlejs.com/badge?q=rut.ts@3.4.0)
+![Open Bundle](https://deno.bundlejs.com/badge?q=rut.ts@4.0.0)
+
+> **v4.0.0 is a major, breaking release** focused on production identity hardening.
+> Read the [CHANGELOG](./CHANGELOG.md) before upgrading from `3.x`.
 
 ## What is a RUT?
 
@@ -111,6 +114,30 @@ For security-sensitive identity flows, prefer `validate(input, { strict: true })
 `clean()` remains intentionally permissive for input normalization. It is useful before display or storage, but it does not prove that the verifier digit is correct. `format()` validates the verifier digit in non-incremental mode and returns `null` in safe mode for invalid complete RUTs.
 
 Error messages are generic (`Invalid RUT input`) so invalid Chilean ID values are not echoed into logs, traces, or user-visible exceptions.
+
+### Accepted input formats (the validation contract)
+
+`validate()` and `isRutLike()` accept **only** these shapes (optionally with leading
+zeros and surrounding whitespace, verifier `k`/`K` case-insensitive):
+
+| Shape | Example | Notes |
+|-------|---------|-------|
+| Compact | `123456785` | 7–8 digit body + verifier |
+| Compact + hyphen | `12345678-5` | |
+| Canonical dotted | `12.345.678-5`, `1.234.567-4` | Chilean grouping from the right |
+
+Anything else is rejected, **including non-canonical dot grouping** that older
+versions accepted: `12.345678-5`, `12345.678-5`, `1.2.3.4.5.6.7.8-5`,
+internal spaces (`12 345 678 5`), commas, and any input longer than 64 chars.
+
+> ⚠️ **Migrating a large dataset?** If your upstream emits RUTs in a non-canonical
+> shape, normalize it to one of the three accepted forms **before** calling
+> `validate()`, or run the differential harness against a representative sample
+> first: `npm run test:differential` (see
+> [`tests/differential.test.ts`](./tests/differential.test.ts); it writes
+> `tests/differential-report.md`). `clean()`/`decompose()` stay permissive and
+> will still parse some of those shapes — never treat their output as
+> "validated".
 
 ### When to use incremental mode
 

--- a/README.md
+++ b/README.md
@@ -3,17 +3,19 @@
   <h1>Rut.ts: Handle chilean RUT values with ease using TypeScript.</h1>
 </div>
 
-![Open Bundle](https://deno.bundlejs.com/badge?q=rut.ts@3.4.0) 
+![Open Bundle](https://deno.bundlejs.com/badge?q=rut.ts@3.4.0)
 
 ## What is a RUT?
 
 The **RUT** (Rol Único Tributario) is the unique Chilean identification number used for:
+
 - Tax purposes
 - Legal identification
 - Government services
 - Banking and financial transactions
 
 **Format**: `XX.XXX.XXX-Y` where:
+
 - `X` = Body (7-8 digits)
 - `Y` = Verifier digit (0-9 or K)
 
@@ -25,15 +27,15 @@ The verifier digit is calculated using the [Modulo 11 algorithm](https://en.wiki
 
 ## Features
 
-- **Validation**: Check if a RUT is valid, with optional strict mode to detect suspicious patterns.
-- **Cleaning**: Remove extraneous characters and leading zeros from RUT strings.
-- **Formatting**: Convert RUTs into a standardized format, with or without dots.
+- **Validation**: Check if a RUT is valid with bounded input parsing, verifier validation, and optional strict mode.
+- **Cleaning**: Permissively remove extraneous characters and leading zeros from RUT strings.
+- **Formatting**: Convert valid RUTs into a standardized format, with or without dots.
 - **Incremental Formatting**: Format RUTs progressively as the user types (ideal for form inputs).
 - **Decomposition**: Split a RUT into its body and verifier digit.
-- **Generation**: Generate valid random RUT numbers.
+- **Generation**: Generate valid random RUT numbers for testing, using Web Crypto when available.
 - **Calculate Verifier**: Calculate the verifier digit for a given RUT body.
-- **Format Detection**: Check if a string looks like a RUT format with `isRutLike`.
-- **Safe Mode**: All functions support `throwOnError: false` to return `null` instead of throwing errors.
+- **Format Detection**: Check if a bounded string looks like a RUT format with `isRutLike`.
+- **Safe Mode**: All safe functions support `throwOnError: false` to return `null` instead of throwing generic errors.
 
 ## Installation
 
@@ -49,41 +51,43 @@ Using [pnpm](https://pnpm.io/):
 
     $ pnpm install rut.ts
 
-
 ## Quick Examples
 
 ```typescript
 import { validate, format, clean, isRutLike, decompose } from 'rut.ts'
 
 // Validation
-validate('12.345.678-5')                      // true
-validate('12.345.678-0')                      // false (wrong verifier)
-validate('11.111.111-1', { strict: true })    // false (strict mode rejects suspicious RUTs)
+validate('12.345.678-5') // true
+validate('12.345.678-0') // false (wrong verifier)
+validate('11.111.111-1', { strict: true }) // false (strict mode rejects suspicious RUTs)
+validate('8.888.888-K', { strict: true }) // false (uppercase K suspicious RUT)
 
 // Formatting
-format('123456785')                // '12.345.678-5'
+format('123456785') // '12.345.678-5'
 format('123456785', { dots: false }) // '12345678-5'
+format('123456789', { throwOnError: false }) // null (wrong verifier)
 
 // Incremental formatting (for form inputs)
-format('1234', { incremental: true })     // '1.234'
+format('1234', { incremental: true }) // '1.234'
 format('12345678', { incremental: true }) // '1.234.567-8' (8 chars = complete)
 format('123456785', { incremental: true }) // '12.345.678-5' (9 chars = complete)
 
 // Cleaning
-clean('12.345.678-5')              // '123456785'
+clean('12.345.678-5') // '123456785'
+// clean() normalizes shape only. Use validate() before accepting a RUT.
 
 // Decomposition
 const { body, verifier } = decompose('12.345.678-5')
-console.log(body)      // '12345678'
-console.log(verifier)  // '5'
+console.log(body) // '12345678'
+console.log(verifier) // '5'
 
 // Format detection (without full validation)
-isRutLike('12.345.678-5')          // true
-isRutLike('not-a-rut')             // false
+isRutLike('12.345.678-5') // true
+isRutLike('not-a-rut') // false
 
 // Safe mode (returns null instead of throwing)
-clean('invalid', { throwOnError: false })  // null
-format('abc', { throwOnError: false })     // null
+clean('invalid', { throwOnError: false }) // null
+format('abc', { throwOnError: false }) // null
 ```
 
 ## Incremental Formatting
@@ -100,14 +104,24 @@ const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
 
 > **Note**: Incremental formatting will format the input progressively even for incomplete RUTs. The formatted output may not represent a valid RUT until the input is complete. Always use `validate()` to verify the final RUT before processing.
 
+## Production Validation Notes
+
+For security-sensitive identity flows, prefer `validate(input, { strict: true })` as the acceptance gate. The validator now rejects malformed dot grouping, caps oversized inputs before parsing, rejects repeated-digit placeholders in strict mode, and compares the verifier digit using the Modulo 11 algorithm.
+
+`clean()` remains intentionally permissive for input normalization. It is useful before display or storage, but it does not prove that the verifier digit is correct. `format()` validates the verifier digit in non-incremental mode and returns `null` in safe mode for invalid complete RUTs.
+
+Error messages are generic (`Invalid RUT input`) so invalid Chilean ID values are not echoed into logs, traces, or user-visible exceptions.
+
 ### When to use incremental mode
 
 **✅ Use incremental when:**
+
 - Formatting user input in real-time as they type
 - Providing immediate visual feedback in form fields
 - Improving UX with progressive formatting
 
 **❌ Don't use incremental when:**
+
 - Formatting already complete/stored RUTs (use default `format()`)
 - Validating RUTs (use `validate()` instead)
 - Processing final form submission values
@@ -115,7 +129,6 @@ const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
 ## Usage
 
 Please refer to [the documentation](https://rut.arrowsw.com/) for more detailed examples.
-
 
 ## TypeScript Types
 
@@ -130,7 +143,6 @@ import type { DecomposedRut, FormatOptions, SafeOptions, ValidateOptions, Verifi
 // ValidateOptions: { strict?: boolean }
 // SafeOptions: { throwOnError?: boolean }
 ```
-
 
 ## Contributing
 

--- a/docs/src/app/docs/layout.jsx
+++ b/docs/src/app/docs/layout.jsx
@@ -21,8 +21,9 @@ export default async function DocsLayout({ children }) {
   return (
     <Layout
       banner={
-        <Banner storageKey="rut-ts-3.4.0-release">
-          🎉 Rut.ts 3.4.0 is released! Check out Safe Mode and improved API.
+        <Banner storageKey="rut-ts-4.0.0-release">
+          🚨 Rut.ts 4.0.0 is released — a major, breaking release with production
+          identity hardening. Read the changelog before upgrading from 3.x.
         </Banner>
       }
       navbar={navbar}

--- a/docs/src/app/page.jsx
+++ b/docs/src/app/page.jsx
@@ -23,7 +23,7 @@ export default function HomePage() {
             marginBottom: '32px',
             fontSize: '14px'
           }}>
-            <span style={{ color: '#10b981' }}>●</span> v3.4.0 — Now with Safe Mode
+            <span style={{ color: '#10b981' }}>●</span> v4.0.0 — Production identity hardening
           </div>
 
           <h1 style={{

--- a/docs/src/content/api-reference.mdx
+++ b/docs/src/content/api-reference.mdx
@@ -6,12 +6,12 @@ Complete API documentation for all rut.ts functions.
 
 ### Validation
 
-- [`validate(rut, options?)`](/docs/features/validate) - Validates a RUT string
+- [`validate(rut, options?)`](/docs/features/validate) - Validates a bounded RUT string and verifier digit
 
 ### Formatting & Cleaning
 
-- [`format(rut, options?)`](/docs/features/format) - Formats a RUT string
-- [`clean(rut, options?)`](/docs/features/clean) - Cleans a RUT string
+- [`format(rut, options?)`](/docs/features/format) - Formats a valid RUT string
+- [`clean(rut, options?)`](/docs/features/clean) - Permissively normalizes a RUT string
 
 ### Decomposition
 
@@ -21,31 +21,25 @@ Complete API documentation for all rut.ts functions.
 
 ### Generation & Calculation
 
-- [`generate()`](/docs/features/generate) - Generates random valid RUT
+- [`generate()`](/docs/features/generate) - Generates random valid test RUTs
 - [`calculateVerifier(body, options?)`](/docs/features/calculate-verifier) - Calculates verifier digit
 
 ### Utilities
 
-- [`isRutLike(rut)`](/docs/features/is-rut-like) - Quick format check
+- [`isRutLike(rut)`](/docs/features/is-rut-like) - Quick bounded format check
 
 ## TypeScript Types
 
 ```typescript copy
-import type { 
-  DecomposedRut,
-  FormatOptions,
-  SafeOptions,
-  ValidateOptions,
-  VerifierDigit
-} from 'rut.ts'
+import type { DecomposedRut, FormatOptions, SafeOptions, ValidateOptions, VerifierDigit } from 'rut.ts'
 ```
 
 ### DecomposedRut
 
 ```typescript copy
 type DecomposedRut = {
-  body: string      // RUT body (7-8 digits)
-  verifier: string  // Verifier digit ('0'-'9' or 'K')
+  body: string // RUT body (7-8 digits)
+  verifier: string // Verifier digit ('0'-'9' or 'K')
 }
 ```
 
@@ -53,9 +47,9 @@ type DecomposedRut = {
 
 ```typescript copy
 type FormatOptions = {
-  incremental?: boolean   // Progressive formatting mode
-  dots?: boolean          // Include dot separators (default: true)
-  throwOnError?: boolean  // Return null on error (default: true)
+  incremental?: boolean // Progressive formatting mode
+  dots?: boolean // Include dot separators (default: true)
+  throwOnError?: boolean // Return null on error (default: true)
 }
 ```
 
@@ -63,7 +57,7 @@ type FormatOptions = {
 
 ```typescript copy
 type SafeOptions = {
-  throwOnError?: boolean  // Return null on error (default: true)
+  throwOnError?: boolean // Return null on error (default: true)
 }
 ```
 
@@ -71,32 +65,29 @@ type SafeOptions = {
 
 ```typescript copy
 type ValidateOptions = {
-  strict?: boolean  // Reject suspicious patterns (default: false)
+  strict?: boolean // Reject suspicious patterns (default: false)
 }
 ```
 
 ### VerifierDigit
 
 ```typescript copy
-type VerifierDigit = 
-  | '0' | '1' | '2' | '3' | '4' 
-  | '5' | '6' | '7' | '8' | '9' 
-  | 'K'
+type VerifierDigit = '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | 'K'
 ```
 
 ## Quick Reference
 
-| Function | Input | Output | Safe Mode | Purpose |
-|----------|-------|--------|-----------|---------|
-| `validate()` | RUT string | boolean | N/A | Check validity |
-| `format()` | RUT string | Formatted string | ✅ | Add formatting |
-| `clean()` | RUT string | Clean string | ✅ | Remove formatting |
-| `decompose()` | RUT string | `{ body, verifier }` | ✅ | Split RUT |
-| `getBody()` | RUT string | Body string | ✅ | Extract body |
-| `getVerifier()` | RUT string | Verifier char | ✅ | Extract verifier |
-| `calculateVerifier()` | Body string | Verifier char | ✅ | Calculate verifier |
-| `generate()` | None | Valid RUT | N/A | Generate random |
-| `isRutLike()` | String | boolean | N/A | Format check |
+| Function              | Input       | Output               | Safe Mode | Purpose                                              |
+| --------------------- | ----------- | -------------------- | --------- | ---------------------------------------------------- |
+| `validate()`          | RUT string  | boolean              | N/A       | Check validity                                       |
+| `format()`            | RUT string  | Formatted string     | ✅        | Add formatting and validate verifier in default mode |
+| `clean()`             | RUT string  | Clean string         | ✅        | Normalize shape without verifier validation          |
+| `decompose()`         | RUT string  | `{ body, verifier }` | ✅        | Split RUT                                            |
+| `getBody()`           | RUT string  | Body string          | ✅        | Extract body                                         |
+| `getVerifier()`       | RUT string  | Verifier char        | ✅        | Extract verifier                                     |
+| `calculateVerifier()` | Body string | Verifier char        | ✅        | Calculate verifier                                   |
+| `generate()`          | None        | Valid RUT            | N/A       | Generate random                                      |
+| `isRutLike()`         | unknown     | boolean              | N/A       | Bounded format check                                 |
 
 ## Common Patterns
 
@@ -108,14 +99,16 @@ import { isRutLike, validate, clean } from 'rut.ts'
 function validateRutPipeline(input: unknown) {
   // Step 1: Type check
   if (typeof input !== 'string') return false
-  
+
   // Step 2: Format check (fast)
   if (!isRutLike(input)) return false
-  
+
   // Step 3: Full validation (slower)
   return validate(input)
 }
 ```
+
+For production identity flows, use `validate(input, { strict: true })` as the final acceptance gate. `clean()` is useful for normalization, but it does not prove that the verifier digit is correct.
 
 ### Safe Processing
 
@@ -125,10 +118,10 @@ import { clean, decompose, calculateVerifier } from 'rut.ts'
 function safeProcessRut(input: string) {
   const cleaned = clean(input, { throwOnError: false })
   if (!cleaned) return null
-  
+
   const parts = decompose(cleaned, { throwOnError: false })
   if (!parts) return null
-  
+
   return parts
 }
 ```
@@ -141,10 +134,10 @@ import { format, validate } from 'rut.ts'
 function formatAndValidate(input: string) {
   const formatted = format(input, { throwOnError: false })
   if (!formatted) return { valid: false, formatted: null }
-  
+
   return {
     valid: validate(formatted),
-    formatted
+    formatted,
   }
 }
 ```

--- a/docs/src/content/examples/error-handling.mdx
+++ b/docs/src/content/examples/error-handling.mdx
@@ -4,7 +4,7 @@ Learn how to handle errors gracefully with rut.ts.
 
 ## Safe Mode
 
-All functions support `throwOnError: false` to return `null` instead of throwing errors.
+Throwing helpers support `throwOnError: false` to return `null` instead of throwing errors.
 
 ### Without Safe Mode (Default)
 
@@ -14,21 +14,23 @@ import { clean, format, decompose } from 'rut.ts'
 try {
   clean('invalid')
 } catch (error) {
-  console.error(error) // Error: String "invalid" is not valid as a RUT input
+  console.error(error) // Error: Invalid RUT input
 }
 
 try {
   format('abc')
 } catch (error) {
-  console.error(error) // Error: String "abc" is not valid as a RUT input
+  console.error(error) // Error: Invalid RUT input
 }
 
 try {
   decompose('123')
 } catch (error) {
-  console.error(error) // Error: String "123" is not valid as a RUT input
+  console.error(error) // Error: Invalid RUT input
 }
 ```
+
+Error messages are intentionally generic so invalid RUT values are not echoed into logs or traces.
 
 ### With Safe Mode
 
@@ -36,13 +38,13 @@ try {
 import { clean, format, decompose } from 'rut.ts'
 
 const cleaned = clean('invalid', { throwOnError: false })
-console.log(cleaned)  // null
+console.log(cleaned) // null
 
 const formatted = format('abc', { throwOnError: false })
-console.log(formatted)  // null
+console.log(formatted) // null
 
 const parts = decompose('123', { throwOnError: false })
-console.log(parts)  // null
+console.log(parts) // null
 ```
 
 ## Graceful Error Handling
@@ -54,35 +56,35 @@ import { validate, format, clean } from 'rut.ts'
 
 function validateRutInput(input: string) {
   // Quick format check
-  const formatted = format(input, { 
+  const formatted = format(input, {
     incremental: true,
-    throwOnError: false 
+    throwOnError: false,
   })
-  
+
   if (!formatted) {
     return { valid: false, error: 'Invalid format' }
   }
-  
+
   // Full validation
   if (!validate(formatted)) {
     return { valid: false, error: 'Invalid RUT or verifier' }
   }
-  
+
   // Strict validation
   if (!validate(formatted, { strict: true })) {
-    return { 
-      valid: false, 
-      error: 'Suspicious RUT pattern detected' 
+    return {
+      valid: false,
+      error: 'Suspicious RUT pattern detected',
     }
   }
-  
+
   // Clean for storage
   const cleaned = clean(formatted)
-  
-  return { 
-    valid: true, 
+
+  return {
+    valid: true,
     cleaned,
-    formatted 
+    formatted,
   }
 }
 ```
@@ -94,24 +96,18 @@ import { validate, clean } from 'rut.ts'
 
 export async function POST(request: Request) {
   const body = await request.json()
-  
+
   // Validate RUT with safe mode
   if (!validate(body.rut)) {
-    return Response.json(
-      { error: 'Invalid RUT' },
-      { status: 400 }
-    )
+    return Response.json({ error: 'Invalid RUT' }, { status: 400 })
   }
-  
+
   // Clean RUT safely
   const cleaned = clean(body.rut, { throwOnError: false })
   if (!cleaned) {
-    return Response.json(
-      { error: 'Cannot process RUT' },
-      { status: 400 }
-    )
+    return Response.json({ error: 'Cannot process RUT' }, { status: 400 })
   }
-  
+
   // Process...
   return Response.json({ success: true, rut: cleaned })
 }
@@ -128,27 +124,27 @@ function processRutSafely(input: string) {
   if (!cleaned) {
     return { error: 'Invalid RUT format', step: 'clean' }
   }
-  
+
   // Step 2: Decompose
   const parts = decompose(cleaned, { throwOnError: false })
   if (!parts) {
     return { error: 'Cannot decompose RUT', step: 'decompose' }
   }
-  
+
   // Step 3: Verify
   const calculated = calculateVerifier(parts.body, { throwOnError: false })
   if (!calculated) {
     return { error: 'Invalid body', step: 'calculate' }
   }
-  
+
   if (calculated !== parts.verifier) {
     return { error: 'Verifier mismatch', step: 'verify' }
   }
-  
+
   return {
     success: true,
     body: parts.body,
-    verifier: parts.verifier
+    verifier: parts.verifier,
   }
 }
 ```
@@ -162,22 +158,22 @@ import { validate, clean } from 'rut.ts'
 
 function getRutError(rut: string): string | null {
   if (!rut) return 'RUT is required'
-  
+
   const cleaned = clean(rut, { throwOnError: false })
   if (!cleaned) {
     if (rut.length < 8) return 'RUT too short'
     if (rut.length > 12) return 'RUT too long'
     return 'Invalid RUT format'
   }
-  
+
   if (!validate(cleaned)) {
     return 'Invalid verifier digit'
   }
-  
+
   if (!validate(cleaned, { strict: true })) {
     return 'Suspicious RUT pattern (e.g., 11.111.111-1)'
   }
-  
+
   return null
 }
 
@@ -197,22 +193,22 @@ const errorMessages = {
   en: {
     required: 'RUT is required',
     invalid: 'Invalid RUT',
-    suspicious: 'Suspicious pattern detected'
+    suspicious: 'Suspicious pattern detected',
   },
   es: {
     required: 'El RUT es requerido',
     invalid: 'RUT inválido',
-    suspicious: 'Patrón sospechoso detectado'
-  }
+    suspicious: 'Patrón sospechoso detectado',
+  },
 }
 
 function validateWithLocale(rut: string, locale: 'en' | 'es' = 'es') {
   const messages = errorMessages[locale]
-  
+
   if (!rut) return messages.required
   if (!validate(rut)) return messages.invalid
   if (!validate(rut, { strict: true })) return messages.suspicious
-  
+
   return null
 }
 ```
@@ -222,21 +218,19 @@ function validateWithLocale(rut: string, locale: 'en' | 'es' = 'es') {
 ```typescript copy
 import { validate, clean } from 'rut.ts'
 
-type Result<T> = 
-  | { success: true; data: T }
-  | { success: false; error: string }
+type Result<T> = { success: true; data: T } | { success: false; error: string }
 
 function parseRut(input: string): Result<string> {
   const cleaned = clean(input, { throwOnError: false })
-  
+
   if (!cleaned) {
     return { success: false, error: 'Invalid format' }
   }
-  
+
   if (!validate(cleaned)) {
     return { success: false, error: 'Invalid verifier' }
   }
-  
+
   return { success: true, data: cleaned }
 }
 

--- a/docs/src/content/features/calculate-verifier.mdx
+++ b/docs/src/content/features/calculate-verifier.mdx
@@ -7,8 +7,8 @@ Calculates the verifier digit for a given RUT body using the Modulo 11 algorithm
 ```typescript copy
 import { calculateVerifier } from 'rut.ts'
 
-calculateVerifier('12345678')  // '5'
-calculateVerifier('24657622')  // 'K'
+calculateVerifier('12345678') // '5'
+calculateVerifier('24657622') // 'K'
 ```
 
 ## Type Signature
@@ -30,6 +30,7 @@ type VerifierDigit = '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' |
 ## Return Value
 
 Returns `VerifierDigit` or `null`:
+
 - A single character: `'0'` to `'9'` or `'K'`
 - `null` if invalid (only in safe mode)
 
@@ -53,13 +54,13 @@ The function implements the **Modulo 11 algorithm**:
 import { calculateVerifier } from 'rut.ts'
 
 // Numeric verifiers
-calculateVerifier('12345678')  // '5'
-calculateVerifier('18972631')  // '7'
-calculateVerifier('11111111')  // '1'
+calculateVerifier('12345678') // '5'
+calculateVerifier('18972631') // '7'
+calculateVerifier('11111111') // '1'
 
 // K verifier (when result is 10)
-calculateVerifier('24657622')  // 'K'
-calculateVerifier('14625621')  // 'K'
+calculateVerifier('24657622') // 'K'
+calculateVerifier('14625621') // 'K'
 ```
 
 ### Building a Complete RUT
@@ -71,7 +72,7 @@ const body = '12345678'
 const verifier = calculateVerifier(body)
 const completeRut = format(body + verifier)
 
-console.log(completeRut)  // '12.345.678-5'
+console.log(completeRut) // '12.345.678-5'
 ```
 
 ### Safe Mode
@@ -81,14 +82,14 @@ import { calculateVerifier } from 'rut.ts'
 
 // Without safe mode (throws)
 try {
-  calculateVerifier('123')  // Too short
+  calculateVerifier('123') // Too short
 } catch (error) {
   console.error(error)
 }
 
 // With safe mode (returns null)
 const result = calculateVerifier('123', { throwOnError: false })
-console.log(result)  // null
+console.log(result) // null
 
 // Useful for form validation
 const handleBodyInput = (body: string) => {
@@ -106,12 +107,15 @@ const handleBodyInput = (body: string) => {
 ```typescript copy
 import { calculateVerifier } from 'rut.ts'
 
-// Accepts formatted input (dots/hyphens removed)
-calculateVerifier('18.972.631')  // '7'
-calculateVerifier('18-972-631')  // '7'
+// Accepts standard body separators (dots/hyphens removed)
+calculateVerifier('18.972.631') // '7'
+calculateVerifier('18-972-631') // '7'
 
 // Handles leading zeros
-calculateVerifier('018972631')  // '7' (zeros removed)
+calculateVerifier('018972631') // '7' (zeros removed)
+
+// Rejects letters and unsupported punctuation
+calculateVerifier('18abc972631', { throwOnError: false }) // null
 ```
 
 ## Validation Rules
@@ -120,7 +124,8 @@ The function validates:
 
 - ✅ Body must be 7-8 digits after cleaning leading zeros
 - ✅ Only numeric characters allowed (no K in body)
-- ✅ Formatting characters (dots, hyphens) are automatically removed
+- ✅ Formatting characters (dots, hyphens, whitespace) are automatically removed
+- ✅ Letters and unsupported punctuation are rejected instead of silently stripped
 
 ## Use Cases
 

--- a/docs/src/content/features/clean.mdx
+++ b/docs/src/content/features/clean.mdx
@@ -2,14 +2,16 @@
 
 Removes extraneous characters and leading zeros from RUT strings, returning a normalized version.
 
+`clean()` is intentionally permissive: it normalizes input shape, but it does not validate the verifier digit. Use `validate()` before accepting a RUT in production flows.
+
 ## Basic Usage
 
 ```typescript copy
 import { clean } from 'rut.ts'
 
-clean('12.345.678-5')  // '123456785'
-clean('  12-345-678-5  ')  // '123456785'
-clean('00012345678K')  // '12345678K'
+clean('12.345.678-5') // '123456785'
+clean('  12-345-678-5  ') // '123456785'
+clean('00012345678K') // '12345678K'
 ```
 
 ## Type Signature
@@ -44,16 +46,16 @@ type SafeOptions = {
 import { clean } from 'rut.ts'
 
 // Remove dots and hyphens
-clean('12.345.678-5')  // '123456785'
+clean('12.345.678-5') // '123456785'
 
 // Remove spaces
-clean(' 12 345 678 5 ')  // '123456785'
+clean(' 12 345 678 5 ') // '123456785'
 
 // Remove leading zeros
-clean('0012345678-5')  // '123456785'
+clean('0012345678-5') // '123456785'
 
 // Uppercase K
-clean('12345678k')  // '12345678K'
+clean('12345678k') // '12345678K'
 ```
 
 ### Safe Mode
@@ -65,7 +67,7 @@ import { clean } from 'rut.ts'
 try {
   clean('invalid')
 } catch (error) {
-  console.error(error) // Error: String "invalid" is not valid as a RUT input
+  console.error(error) // Error: Invalid RUT input
 }
 
 // With safe mode (returns null)
@@ -76,7 +78,7 @@ console.log(result) // null
 const handleInput = (value: string) => {
   const cleaned = clean(value, { throwOnError: false })
   if (cleaned) {
-    // Process valid RUT
+    // Process normalized RUT shape, then validate before accepting it
     saveToDatabase(cleaned)
   } else {
     // Show error to user
@@ -91,19 +93,19 @@ const handleInput = (value: string) => {
 import { clean } from 'rut.ts'
 
 // Multiple hyphens
-clean('12-345-678-5')  // '123456785'
+clean('12-345-678-5') // '123456785'
 
 // Special characters
-clean('12#345$678%5')  // '123456785'
+clean('12#345$678%5') // '123456785'
 
 // Mixed formatting
-clean('12.345-678 5')  // '123456785'
+clean('12.345-678 5') // '123456785'
 
 // Parentheses
-clean('(12.345.678-5)')  // '123456785'
+clean('(12.345.678-5)') // '123456785'
 
 // Leading zeros (removed)
-clean('000012345678-5')  // '123456785'
+clean('000012345678-5') // '123456785'
 ```
 
 ## Validation Rules
@@ -114,6 +116,11 @@ The function validates:
 - ✅ K (if present) must be at the end
 - ✅ Only one K allowed
 - ✅ Only digits and K allowed
+
+It does not validate:
+
+- The Modulo 11 verifier digit
+- Whether the original input used canonical dot or hyphen grouping
 
 ## Use Cases
 

--- a/docs/src/content/features/decompose.mdx
+++ b/docs/src/content/features/decompose.mdx
@@ -37,6 +37,12 @@ Returns `DecomposedRut` object or `null`:
 - **`body`** - The RUT body (7-8 digits, cleaned)
 - **`verifier`** - The verifier digit ('0'-'9' or 'K')
 
+> **v4.0.0:** `decompose()` is a permissive normalizer built on `clean()` — it
+> does **not** validate the verifier digit, and it accepts some shapes that
+> `validate()` rejects (e.g. `12.345678-5`). Never treat a non-`null` result as
+> "validated"; gate acceptance with `validate()`. Non-string inputs return
+> `null` in safe mode (no `TypeError`).
+
 ## Examples
 
 ### Basic Decomposition

--- a/docs/src/content/features/format.mdx
+++ b/docs/src/content/features/format.mdx
@@ -1,13 +1,13 @@
 # format()
 
-Converts RUT strings into a standardized format with dots and hyphens.
+Converts valid RUT strings into a standardized format with dots and hyphens.
 
 ## Basic Usage
 
 ```typescript copy
 import { format } from 'rut.ts'
 
-format('123456785')                  // '12.345.678-5'
+format('123456785') // '12.345.678-5'
 format('123456785', { dots: false }) // '12345678-5'
 ```
 
@@ -35,7 +35,7 @@ type FormatOptions = {
 
 ## Return Value
 
-- **Default mode**: Returns formatted RUT string or throws error
+- **Default mode**: Returns formatted RUT string or throws error when the complete RUT is malformed or has the wrong verifier
 - **Safe mode**: Returns formatted RUT string or `null` if invalid
 - **Incremental mode**: Always returns a string (even for partial/invalid inputs)
 
@@ -47,17 +47,20 @@ type FormatOptions = {
 import { format } from 'rut.ts'
 
 // With dots (default)
-format('123456785')  // '12.345.678-5'
-format('9068826K')   // '9.068.826-K'
+format('123456785') // '12.345.678-5'
+format('9068826K') // '9.068.826-K'
 
 // Without dots
-format('123456785', { dots: false })  // '12345678-5'
-format('9068826K', { dots: false })   // '9068826-K'
+format('123456785', { dots: false }) // '12345678-5'
+format('9068826K', { dots: false }) // '9068826-K'
 
 // Handles any input format
-format('12.345.678-5')   // '12.345.678-5' (already formatted)
-format('12-345-678-5')   // '12.345.678-5'
-format('  123456785  ')  // '12.345.678-5'
+format('12.345.678-5') // '12.345.678-5' (already formatted)
+format('12-345-678-5') // '12.345.678-5'
+format('  123456785  ') // '12.345.678-5'
+
+// Rejects wrong verifier digits in non-incremental mode
+format('123456789', { throwOnError: false }) // null
 ```
 
 ### Incremental Formatting
@@ -68,21 +71,22 @@ Perfect for real-time formatting as users type:
 import { format } from 'rut.ts'
 
 // Progressive formatting
-format('1', { incremental: true })         // '1'
-format('12', { incremental: true })        // '12'
-format('123', { incremental: true })       // '123'
-format('1234', { incremental: true })      // '1.234'
-format('12345', { incremental: true })     // '12.345'
-format('123456', { incremental: true })    // '123.456'
-format('1234567', { incremental: true })   // '1.234.567'
-format('12345678', { incremental: true })  // '1.234.567-8' (hyphen at 8+ chars)
+format('1', { incremental: true }) // '1'
+format('12', { incremental: true }) // '12'
+format('123', { incremental: true }) // '123'
+format('1234', { incremental: true }) // '1.234'
+format('12345', { incremental: true }) // '12.345'
+format('123456', { incremental: true }) // '123.456'
+format('1234567', { incremental: true }) // '1.234.567'
+format('12345678', { incremental: true }) // '1.234.567-8' (hyphen at 8+ chars)
 format('123456785', { incremental: true }) // '12.345.678-5'
 ```
 
 import { Callout } from 'nextra/components'
 
 <Callout type="warning">
-  **Important:** Incremental mode formats even incomplete/invalid RUTs. Always use `validate()` to check the final RUT before processing.
+  **Important:** Incremental mode formats even incomplete/invalid RUTs. Always use `validate()` to check the final RUT
+  before processing.
 </Callout>
 
 ### React Example
@@ -102,7 +106,7 @@ function RutInput() {
   }
 
   return (
-    <input 
+    <input
       value={rut}
       onChange={handleChange}
       placeholder="12.345.678-5"
@@ -121,7 +125,7 @@ import { format } from 'rut.ts'
 try {
   format('123')
 } catch (error) {
-  console.error(error) // Error: String "123" is not valid as a RUT input
+  console.error(error) // Error: Invalid RUT input
 }
 
 // With safe mode (returns null)
@@ -129,21 +133,23 @@ const result = format('123', { throwOnError: false })
 console.log(result) // null
 
 // Combined with other options
-format('invalid', { 
-  dots: false, 
-  throwOnError: false 
+format('invalid', {
+  dots: false,
+  throwOnError: false,
 }) // null
 ```
 
 ## When to Use Incremental Mode
 
 ### ✅ Use incremental when:
+
 - Formatting user input in real-time as they type
 - Providing immediate visual feedback in form fields
 - Improving UX with progressive formatting
 - Building RUT input components
 
 ### ❌ Don't use incremental when:
+
 - Formatting already complete/stored RUTs (use default `format()`)
 - Validating RUTs (use `validate()` instead)
 - Processing final form submission values
@@ -155,16 +161,16 @@ format('invalid', {
 import { format } from 'rut.ts'
 
 // Empty string
-format('')  // ''
+format('') // ''
 
 // Leading zeros removed
-format('00012345678')  // '1.234.567-8'
+format('000123456785') // '12.345.678-5'
 
 // K verifier (uppercase)
-format('12345678k')  // '12.345.678-K'
+format('14625621k') // '14.625.621-K'
 
 // Already formatted
-format('12.345.678-5')  // '12.345.678-5'
+format('12.345.678-5') // '12.345.678-5'
 ```
 
 ## Use Cases

--- a/docs/src/content/features/generate.mdx
+++ b/docs/src/content/features/generate.mdx
@@ -8,7 +8,7 @@ Generates random valid RUT numbers for testing and development purposes.
 import { generate } from 'rut.ts'
 
 const randomRut = generate()
-console.log(randomRut)  // '18.972.631-7'
+console.log(randomRut) // '18.972.631-7'
 ```
 
 ## Type Signature
@@ -24,10 +24,12 @@ None. The function takes no parameters.
 ## Return Value
 
 Returns a `string` containing:
+
 - A randomly generated RUT
 - Already formatted with dots and hyphen (`XX.XXX.XXX-Y`)
 - Guaranteed to be valid (passes `validate()`)
 - Body in range: 10,000,000 - 99,999,999
+- Non-suspicious body (repeated-digit placeholders are skipped)
 
 ## Examples
 
@@ -37,7 +39,7 @@ Returns a `string` containing:
 import { generate } from 'rut.ts'
 
 const rut = generate()
-console.log(rut)  // e.g., '45.123.789-2'
+console.log(rut) // e.g., '45.123.789-2'
 ```
 
 ### Generate Multiple RUTs
@@ -59,7 +61,7 @@ import { generate, validate } from 'rut.ts'
 const testRuts = Array.from({ length: 100 }, () => generate())
 
 // All generated RUTs are valid
-testRuts.forEach(rut => {
+testRuts.forEach((rut) => {
   console.assert(validate(rut) === true)
 })
 ```
@@ -73,13 +75,13 @@ import { generate, decompose } from 'rut.ts'
 const testUsers = Array.from({ length: 50 }, (_, i) => {
   const rut = generate()
   const { body, verifier } = decompose(rut)
-  
+
   return {
     id: i + 1,
     name: `Test User ${i + 1}`,
     rut: rut,
     rutBody: body,
-    rutVerifier: verifier
+    rutVerifier: verifier,
   }
 })
 
@@ -105,7 +107,7 @@ Generated RUTs follow this pattern:
 XX.XXX.XXX-Y
 ││  │   │  └─ Verifier digit (0-9 or K)
 ││  │   └──── Last 3 digits of body
-││  └──────── Middle 3 digits of body  
+││  └──────── Middle 3 digits of body
 │└─────────── First 2 digits of body
 └──────────── Always 8 digits total in body
 ```
@@ -126,16 +128,16 @@ import { generate, validate } from 'rut.ts'
 describe('RUT validation', () => {
   test('validates 1000 generated RUTs', () => {
     const ruts = Array.from({ length: 1000 }, () => generate())
-    
-    ruts.forEach(rut => {
+
+    ruts.forEach((rut) => {
       expect(validate(rut)).toBe(true)
     })
   })
-  
+
   test('generated RUTs pass strict validation', () => {
     const ruts = Array.from({ length: 100 }, () => generate())
-    
-    ruts.forEach(rut => {
+
+    ruts.forEach((rut) => {
       expect(validate(rut, { strict: true })).toBe(true)
     })
   })
@@ -148,6 +150,8 @@ describe('RUT validation', () => {
 - Generated RUTs use **realistic** number ranges
 - Verifier is **automatically calculated** using Modulo 11
 - Output is **always formatted** with dots and hyphen
+- Web Crypto is used when available; older runtimes fall back to `Math.random()`
+- Generated RUTs are for tests, demos, and development data. Do not use them to assign real identities.
 
 ## Related Functions
 

--- a/docs/src/content/features/get-body.mdx
+++ b/docs/src/content/features/get-body.mdx
@@ -27,8 +27,12 @@ function getBody(rut: string, options: { throwOnError: true }): string
 
 ## Return Value
 
-- **Default mode**: Returns body string (7-8 digits) or throws error
+- **Default mode**: Returns body string (7-8 digits) or throws a generic `Invalid RUT input` error
 - **Safe mode**: Returns body string or `null` if invalid
+
+> **v4.0.0:** non-string inputs (numbers, `null`, `undefined`, objects) are
+> treated like any other invalid input — they return `null` in safe mode and
+> throw the generic error otherwise, instead of throwing a `TypeError`.
 
 ## Examples
 

--- a/docs/src/content/features/get-verifier.mdx
+++ b/docs/src/content/features/get-verifier.mdx
@@ -33,6 +33,10 @@ Returns `VerifierDigit` or `null`:
 - A single character: `'0'` to `'9'` or `'K'` (always uppercase)
 - `null` if invalid (only in safe mode)
 
+> **v4.0.0:** non-string inputs (numbers, `null`, `undefined`, objects) return
+> `null` in safe mode and throw the generic `Invalid RUT input` error otherwise,
+> instead of throwing a `TypeError`.
+
 ## Examples
 
 ### Basic Extraction

--- a/docs/src/content/features/is-rut-like.mdx
+++ b/docs/src/content/features/is-rut-like.mdx
@@ -1,29 +1,30 @@
 # isRutLike()
 
-Quick format check to determine if a string looks like a RUT, without validating the verifier digit.
+Quick bounded format check to determine if a value looks like a RUT, without validating the verifier digit.
 
 ## Basic Usage
 
 ```typescript copy
 import { isRutLike } from 'rut.ts'
 
-isRutLike('12.345.678-9')  // true
-isRutLike('not-a-rut')     // false
+isRutLike('12.345.678-9') // true
+isRutLike('not-a-rut') // false
 ```
 
 ## Type Signature
 
 ```typescript copy
-function isRutLike(rut: string): boolean
+function isRutLike(rut: unknown): boolean
 ```
 
 ## Parameters
 
-- **`rut`** (`string`) - The string to check
+- **`rut`** (`unknown`) - The value to check
 
 ## Return Value
 
 Returns `boolean`:
+
 - `true` if the string looks like a RUT format
 - `false` otherwise
 
@@ -35,11 +36,11 @@ Returns `boolean`:
 import { isRutLike } from 'rut.ts'
 
 // All RUT-like formats
-isRutLike('12.345.678-9')   // true (standard format)
-isRutLike('12345678-9')     // true (no dots)
-isRutLike('123456789')      // true (no formatting)
-isRutLike('1.234.567-K')    // true (7-digit body)
-isRutLike('09.068.826-K')   // true (leading zeros)
+isRutLike('12.345.678-9') // true (standard format)
+isRutLike('12345678-9') // true (no dots)
+isRutLike('123456789') // true (no formatting)
+isRutLike('1.234.567-K') // true (7-digit body)
+isRutLike('09.068.826-K') // true (leading zeros)
 ```
 
 ### Invalid Formats
@@ -47,10 +48,12 @@ isRutLike('09.068.826-K')   // true (leading zeros)
 ```typescript copy
 import { isRutLike } from 'rut.ts'
 
-isRutLike('abcdefgh')      // false (letters)
-isRutLike('')              // false (empty)
-isRutLike('12.34.56-7')    // false (wrong dot pattern)
-isRutLike('12,345,678-9')  // false (commas not supported)
+isRutLike('abcdefgh') // false (letters)
+isRutLike('') // false (empty)
+isRutLike('12.34.56-7') // false (wrong dot pattern)
+isRutLike('12.345678-9') // false (ambiguous dot grouping)
+isRutLike('12,345,678-9') // false (commas not supported)
+isRutLike(123456789) // false (not a string)
 ```
 
 ## Difference from validate()
@@ -58,9 +61,8 @@ isRutLike('12,345,678-9')  // false (commas not supported)
 import { Callout } from 'nextra/components'
 
 <Callout type="info">
-  **`isRutLike()`** only checks if the format looks correct. It does NOT validate the verifier digit.
-  
-  Use **`validate()`** for full validation including verifier digit check.
+  **`isRutLike()`** only checks if the format looks correct. It does NOT validate the verifier digit. Use
+  **`validate()`** for full validation including verifier digit check.
 </Callout>
 
 ```typescript copy
@@ -68,8 +70,8 @@ import { isRutLike, validate } from 'rut.ts'
 
 const rut = '12.345.678-0' // Wrong verifier (should be 5)
 
-isRutLike(rut)   // true ✅ (format is correct)
-validate(rut)    // false ❌ (verifier is wrong)
+isRutLike(rut) // true ✅ (format is correct)
+validate(rut) // false ❌ (verifier is wrong)
 ```
 
 ## Use Cases
@@ -84,7 +86,7 @@ function handleInput(value: string) {
     showError('Please enter a valid RUT format')
     return
   }
-  
+
   // Continue with full validation
   if (validate(value)) {
     saveRut(value)
@@ -97,13 +99,7 @@ function handleInput(value: string) {
 ```typescript copy
 import { isRutLike } from 'rut.ts'
 
-const inputs = [
-  '12.345.678-5',
-  'invalid',
-  '18.972.631-7',
-  'abc',
-  '9068826K'
-]
+const inputs = ['12.345.678-5', 'invalid', '18.972.631-7', 'abc', '9068826K']
 
 // Quick filter for RUT-like strings
 const potentialRuts = inputs.filter(isRutLike)
@@ -121,7 +117,7 @@ function validateRut(input: unknown): boolean {
   if (typeof input !== 'string' || !isRutLike(input)) {
     return false
   }
-  
+
   // Then do full validation (more expensive)
   return validate(input)
 }
@@ -130,9 +126,10 @@ function validateRut(input: unknown): boolean {
 ## Performance
 
 `isRutLike()` is **faster** than `validate()` because:
-- Only checks format with regex
-- Doesn't calculate verifier digit
-- Doesn't decompose the RUT
+
+- It checks type, length, and accepted RUT shapes first
+- It does not calculate the verifier digit
+- It rejects oversized input before running the shape checks
 
 Use it for **quick filtering** before full validation.
 

--- a/docs/src/content/features/validate.mdx
+++ b/docs/src/content/features/validate.mdx
@@ -1,6 +1,6 @@
 # validate()
 
-Validates a given RUT string, checking both format and verifier digit.
+Validates a given RUT string, checking bounded input shape and verifier digit.
 
 ## Basic Usage
 
@@ -9,7 +9,7 @@ import { validate } from 'rut.ts'
 
 validate('12.345.678-5') // true
 validate('12.345.678-0') // false (wrong verifier)
-validate('invalid')      // false
+validate('invalid') // false
 ```
 
 ## Type Signature
@@ -26,11 +26,12 @@ type ValidateOptions = {
 
 - **`rut`** (`unknown`) - The RUT to validate. Accepts unknown types for type safety.
 - **`options`** (optional) - Validation options
-  - **`strict`** (`boolean`, default: `false`) - If true, rejects suspicious patterns
+  - **`strict`** (`boolean`, default: `false`) - If true, rejects suspicious repeated-digit placeholders
 
 ## Return Value
 
 Returns `boolean`:
+
 - `true` if the RUT is valid
 - `false` if the RUT is invalid or not a string
 
@@ -42,17 +43,18 @@ Returns `boolean`:
 import { validate } from 'rut.ts'
 
 // Valid RUTs
-validate('12.345.678-5')   // true
-validate('12345678-5')     // true (without dots)
-validate('123456785')      // true (no formatting)
-validate('14.625.621-K')   // true (K verifier)
+validate('12.345.678-5') // true
+validate('12345678-5') // true (without dots)
+validate('123456785') // true (no formatting)
+validate('14.625.621-K') // true (K verifier)
 
 // Invalid RUTs
-validate('12.345.678-0')   // false (wrong verifier)
-validate('abc')            // false
-validate('')               // false
-validate(null)             // false
-validate(123)              // false
+validate('12.345.678-0') // false (wrong verifier)
+validate('12.345678-5') // false (malformed dot grouping)
+validate('abc') // false
+validate('') // false
+validate(null) // false
+validate(123) // false
 ```
 
 ### Strict Mode
@@ -63,14 +65,33 @@ Strict mode rejects suspicious patterns like repeated digits:
 import { validate } from 'rut.ts'
 
 // Suspicious RUTs (technically valid, but unlikely to be real)
-validate('11.111.111-1', { strict: true })  // false
-validate('22.222.222-2', { strict: true })  // false
-validate('33.333.333-3', { strict: true })  // false
+validate('11.111.111-1', { strict: true }) // false
+validate('22.222.222-2', { strict: true }) // false
+validate('33.333.333-3', { strict: true }) // false
+validate('8.888.888-K', { strict: true }) // false
 
 // Without strict mode, these pass
-validate('11.111.111-1')  // true
-validate('22.222.222-2')  // true
+validate('11.111.111-1') // true
+validate('22.222.222-2') // true
 ```
+
+### Accepted Input Shapes
+
+`validate()` accepts the common Chilean RUT shapes and rejects ambiguous grouping before calculating the verifier digit:
+
+```typescript copy
+import { validate } from 'rut.ts'
+
+validate('12.345.678-5') // true
+validate('12345678-5') // true
+validate('123456785') // true
+
+validate('12.345678-5') // false
+validate('12345.678-5') // false
+validate('12,345,678-5') // false
+```
+
+Inputs are length-capped before parsing so very large strings fail fast instead of spending time in regular expressions.
 
 ### Type Safety
 
@@ -86,9 +107,9 @@ function processUserInput(input: unknown) {
   }
 }
 
-processUserInput('12.345.678-5')  // Valid RUT
-processUserInput(12345678)        // Silent fail (returns false)
-processUserInput(null)            // Silent fail (returns false)
+processUserInput('12.345.678-5') // Valid RUT
+processUserInput(12345678) // Silent fail (returns false)
+processUserInput(null) // Silent fail (returns false)
 ```
 
 ## Use Cases

--- a/docs/src/content/index.mdx
+++ b/docs/src/content/index.mdx
@@ -4,8 +4,12 @@ import { Cards, Callout, Tabs } from 'nextra/components'
 
 Handle Chilean RUT values with ease using TypeScript.
 
-<Callout type="info" emoji="✨">
-  **Version 3.4.0 is out!** New safe mode, improved API, and better TypeScript types.
+<Callout type="warning" emoji="🚨">
+  **Version 4.0.0 is out — this is a major, breaking release.** Production identity
+  hardening: bounded input parsing (ReDoS-safe), strict format validation, verifier
+  checking in `format()`, generic error messages, and a crypto-backed `generate()`.
+  Review the [changelog](https://github.com/arrowsw/rut.ts/blob/canary/CHANGELOG.md)
+  before upgrading from `3.x`.
 </Callout>
 
 ## What is a RUT?

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rut.ts",
-  "version": "3.4.0",
+  "version": "4.0.0",
   "type": "module",
   "description": "Handle chilean RUT values with ease.",
   "author": "arrowsw",
@@ -28,6 +28,7 @@
     "lint": "eslint \"{**/*,*}.{js,ts,jsx,tsx}\"",
     "prettier": "prettier --write \"{src,tests,example/src}/**/*.{js,ts,jsx,tsx}\"",
     "test": "jest --config jest.config.cjs",
+    "test:differential": "RUN_DIFFERENTIAL=1 jest --config jest.config.cjs tests/differential.test.ts",
     "prepare": "npm run build",
     "prepublishOnly": "npm run test && npm run prettier && npm run lint",
     "minify:esm": "terser dist/esm/index.js -o dist/esm/index.min.js -c -m",

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,8 +64,10 @@ const isCleanRut = (rut: string): boolean => {
 const parseRutLike = (rut: unknown): DecomposedRut | null => {
   if (!isBoundedString(rut)) return null
 
+  // `isBoundedString` already capped the raw length; trimming can only shrink it,
+  // so the only remaining case to reject is a whitespace-only input.
   const input = rut.trim()
-  if (input.length === 0 || input.length > MAX_RUT_INPUT_LENGTH) return null
+  if (input.length === 0) return null
 
   const hasValidShape =
     patterns.compact.test(input) || patterns.compactWithHyphen.test(input) || patterns.dotted.test(input)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,18 @@
-type ValidationPatterns = { rutLike: RegExp; suspicious: RegExp; cleaning: RegExp }
+type ValidationPatterns = {
+  compact: RegExp
+  compactWithHyphen: RegExp
+  dotted: RegExp
+  invalidRutChars: RegExp
+  bodySeparators: RegExp
+  bodyDigits: RegExp
+}
 type DecomposedRut = { body: string; verifier: string }
 type FormatOptions = { incremental?: boolean; dots?: boolean; throwOnError?: boolean }
 type SafeOptions = { throwOnError?: boolean }
 type ValidateOptions = { strict?: boolean }
 type VerifierDigit = '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | 'K'
 
-export const getInvalidRutError = (rut: string): string => `String "${rut}" is not valid as a RUT input`
+export const getInvalidRutError = (_rut?: unknown): string => 'Invalid RUT input'
 
 /** Helper to create SafeOptions with explicit throwOnError boolean */
 const withThrowOption = (throwOnError?: boolean): { throwOnError: boolean } => ({
@@ -14,18 +21,126 @@ const withThrowOption = (throwOnError?: boolean): { throwOnError: boolean } => (
 
 const MIN_RUT_LENGTH = 8
 const MAX_RUT_LENGTH = 9
-
-/** Internal helper to clean RUT without length validation (used for incremental formatting) */
-const cleanRaw = (rut: string): string => rut.replace(/^0+|[^0-9kK]+/g, '').toUpperCase()
+const MIN_BODY_LENGTH = 7
+const MAX_BODY_LENGTH = 8
+const MAX_RUT_INPUT_LENGTH = 64
+const MIN_GENERATED_BODY = 10000000
+const MAX_GENERATED_BODY = 99999999
+const UINT32_RANGE = 0x100000000
 
 const patterns: ValidationPatterns = {
-  cleaning: /^0+|[^0-9kK]+/g,
-  rutLike: /^0*(\d{1,3}(\.?\d{3})*)-?([\dkK])$/,
-  suspicious: /^(\d)\1?\.?(\1{3})\.?(\1{3})-?(\d|k)?$/,
+  compact: /^0*\d{7,8}[\dkK]$/,
+  compactWithHyphen: /^0*\d{7,8}-[\dkK]$/,
+  dotted: /^0*\d{1,3}\.\d{3}\.\d{3}-?[\dkK]$/,
+  invalidRutChars: /[^0-9kK]+/g,
+  bodySeparators: /[.\-\s]+/g,
+  bodyDigits: /^\d+$/,
+}
+
+const fail = <T>(input: unknown, shouldThrow: boolean): T | null => {
+  if (shouldThrow) throw new Error(getInvalidRutError(input))
+  return null
+}
+
+const isBoundedString = (input: unknown): input is string =>
+  typeof input === 'string' && input.length > 0 && input.length <= MAX_RUT_INPUT_LENGTH
+
+const normalizeRutValue = (rut: string): string =>
+  rut.replace(patterns.invalidRutChars, '').replace(/^0+/, '').toUpperCase()
+
+const isCleanRut = (rut: string): boolean => {
+  if (rut.length < MIN_RUT_LENGTH || rut.length > MAX_RUT_LENGTH) return false
+
+  const body = rut.slice(0, -1)
+  const verifier = rut.slice(-1)
+  return (
+    body.length >= MIN_BODY_LENGTH &&
+    body.length <= MAX_BODY_LENGTH &&
+    patterns.bodyDigits.test(body) &&
+    /^[\dK]$/.test(verifier)
+  )
+}
+
+const parseRutLike = (rut: unknown): DecomposedRut | null => {
+  if (!isBoundedString(rut)) return null
+
+  const input = rut.trim()
+  if (input.length === 0 || input.length > MAX_RUT_INPUT_LENGTH) return null
+
+  const hasValidShape =
+    patterns.compact.test(input) || patterns.compactWithHyphen.test(input) || patterns.dotted.test(input)
+  if (!hasValidShape) return null
+
+  const cleaned = normalizeRutValue(input)
+  if (!isCleanRut(cleaned)) return null
+
+  return {
+    body: cleaned.slice(0, -1),
+    verifier: cleaned.slice(-1),
+  }
+}
+
+/** Internal helper to clean RUT without complete-RUT validation (used for incremental formatting) */
+const cleanRaw = (rut: string): string => {
+  const cleaned = normalizeRutValue(rut.slice(0, MAX_RUT_INPUT_LENGTH))
+  const digits = cleaned.replace(/K/g, '')
+  return (cleaned.endsWith('K') ? `${digits}K` : digits).slice(0, MAX_RUT_LENGTH)
+}
+
+const normalizeRutBody = (rutBody: unknown): string | null => {
+  if (!isBoundedString(rutBody)) return null
+
+  const cleanedRut = rutBody.replace(patterns.bodySeparators, '').replace(/^0+/, '')
+  if (cleanedRut.length < MIN_BODY_LENGTH || cleanedRut.length > MAX_BODY_LENGTH) return null
+  if (!patterns.bodyDigits.test(cleanedRut)) return null
+
+  return cleanedRut
+}
+
+const calculateVerifierForBody = (rutBody: string): VerifierDigit => {
+  let sum = 0
+  let multiplier = 2
+
+  for (let index = rutBody.length - 1; index >= 0; index -= 1) {
+    sum += (rutBody.charCodeAt(index) - 48) * multiplier
+    multiplier = multiplier === 7 ? 2 : multiplier + 1
+  }
+
+  const checkDigit = 11 - (sum % 11)
+  return (checkDigit === 11 ? '0' : checkDigit === 10 ? 'K' : checkDigit.toString()) as VerifierDigit
+}
+
+const isSuspicious = (body: string): boolean => {
+  const firstDigit = body[0]
+  for (let index = 1; index < body.length; index += 1) {
+    if (body[index] !== firstDigit) return false
+  }
+  return true
+}
+
+const randomIntInclusive = (min: number, max: number): number => {
+  const range = max - min + 1
+  const cryptoSource = globalThis.crypto
+
+  if (cryptoSource?.getRandomValues) {
+    const maxUnbiased = Math.floor(UINT32_RANGE / range) * range
+    const buffer = new Uint32Array(1)
+    let value = 0
+
+    do {
+      cryptoSource.getRandomValues(buffer)
+      value = buffer[0]
+    } while (value >= maxUnbiased)
+
+    return min + (value % range)
+  }
+
+  return min + Math.floor(Math.random() * range)
 }
 
 /**
  * Cleans the input string by removing leading zeros, non-numeric characters, and ensures the RUT is uppercased.
+ * This is a permissive normalization helper and does not validate the verifier digit.
  * @param {string} rut - The RUT string to clean.
  * @param {SafeOptions} [options] - Configuration options.
  * @param {boolean} [options.throwOnError=true] - If true (default), throws an error for invalid RUTs. If false, returns null.
@@ -38,17 +153,10 @@ function clean(rut: string, options: { throwOnError: true }): string
 function clean(rut: string, options?: SafeOptions): string | null
 function clean(rut: string, options?: SafeOptions): string | null {
   const shouldThrow = options?.throwOnError ?? true
-  const cleanRut = rut.replace(patterns.cleaning, '').toUpperCase()
+  if (!isBoundedString(rut)) return fail<string>(rut, shouldThrow)
 
-  if (cleanRut.length < MIN_RUT_LENGTH || cleanRut.length > MAX_RUT_LENGTH) {
-    if (shouldThrow) throw new Error(getInvalidRutError(rut))
-    return null
-  }
-
-  if (cleanRut.includes('K') && cleanRut.indexOf('K') !== cleanRut.length - 1) {
-    if (shouldThrow) throw new Error(getInvalidRutError(rut))
-    return null
-  }
+  const cleanRut = normalizeRutValue(rut)
+  if (!isCleanRut(cleanRut)) return fail<string>(rut, shouldThrow)
 
   return cleanRut
 }
@@ -113,18 +221,10 @@ function decompose(rut: string, options?: SafeOptions): DecomposedRut | null {
 /**
  * Checks if a string has a valid RUT format (without validating the verifier digit).
  * Useful for quick format validation in UI before full validation.
- * @param {string} rut - The string to check.
+ * @param {unknown} rut - The value to check.
  * @returns {boolean} True if the string looks like a RUT format, false otherwise.
  */
-const isRutLike = (rut: string): boolean => patterns.rutLike.test(rut)
-
-/**
- * Checks if a RUT matches suspicious patterns (e.g., 11.111.111-1, 22.222.222-2).
- * These RUTs are technically valid but often used as placeholder/test data.
- * @param {string} rut - The RUT string to check.
- * @returns {boolean} True if the RUT is suspicious, false otherwise.
- */
-const isSuspicious = (rut: string): boolean => patterns.suspicious.test(rut)
+const isRutLike = (rut: unknown): boolean => parseRutLike(rut) !== null
 
 /**
  * Calculates the verifier digit for a given RUT body.
@@ -140,29 +240,10 @@ function calculateVerifier(rutBody: string, options: { throwOnError: true }): Ve
 function calculateVerifier(rutBody: string, options?: SafeOptions): VerifierDigit | null
 function calculateVerifier(rutBody: string, options?: SafeOptions): VerifierDigit | null {
   const throwOpt = withThrowOption(options?.throwOnError)
+  const cleanedRut = normalizeRutBody(rutBody)
 
-  // Use cleanRaw since we're validating a body (7-8 digits), not a complete RUT (8-9 chars)
-  const cleanedRut = cleanRaw(rutBody)
-
-  // Body should be 7-8 digits (not 8-9 like complete RUT)
-  if (cleanedRut.length < 7 || cleanedRut.length > 8) {
-    if (throwOpt.throwOnError) throw new Error(getInvalidRutError(rutBody))
-    return null
-  }
-
-  // Body should only contain digits (no K allowed in body)
-  if (!/^\d+$/.test(cleanedRut)) {
-    if (throwOpt.throwOnError) throw new Error(getInvalidRutError(rutBody))
-    return null
-  }
-
-  const sum = cleanedRut
-    .split('')
-    .reverse()
-    .reduce((acc, digit, index) => acc + Number(digit) * ((index % 6) + 2), 0)
-
-  const checkDigit = 11 - (sum % 11)
-  return (checkDigit === 11 ? '0' : checkDigit === 10 ? 'K' : checkDigit.toString()) as VerifierDigit
+  if (cleanedRut === null) return fail<VerifierDigit>(rutBody, throwOpt.throwOnError)
+  return calculateVerifierForBody(cleanedRut)
 }
 
 /**
@@ -173,17 +254,11 @@ function calculateVerifier(rutBody: string, options?: SafeOptions): VerifierDigi
  * @returns {boolean} True if the RUT is valid, false otherwise.
  */
 const validate = (rut: unknown, options?: ValidateOptions): boolean => {
-  if (typeof rut !== 'string' || rut.length === 0) return false
-  if (!isRutLike(rut)) return false
-  if (options?.strict && isSuspicious(rut)) return false
-
-  const decomposed = decompose(rut, { throwOnError: false })
+  const decomposed = parseRutLike(rut)
   if (!decomposed) return false
+  if (options?.strict && isSuspicious(decomposed.body)) return false
 
-  const calculatedVerifier = calculateVerifier(decomposed.body, { throwOnError: false })
-  if (!calculatedVerifier) return false
-
-  return calculatedVerifier === decomposed.verifier
+  return calculateVerifierForBody(decomposed.body) === decomposed.verifier
 }
 
 /**
@@ -213,18 +288,16 @@ function format(rut: string, options?: FormatOptions): string | null {
     throwOnError: options?.throwOnError ?? true,
   }
 
+  if (typeof rut !== 'string') return fail<string>(rut, opts.throwOnError)
   if (rut.length === 0) return ''
 
-  // Incremental mode: format progressively without length validation
   if (opts.incremental) {
     const rawClean = cleanRaw(rut)
     if (rawClean.length === 0) return ''
 
-    // For short inputs (< 8 chars), only add dots, no hyphen
     if (rawClean.length < MIN_RUT_LENGTH) {
       if (!opts.dots || rawClean.length <= 3) return rawClean
 
-      // Add dots every 3 digits from right
       let result = rawClean.slice(-3)
       for (let i = 3; i < rawClean.length; i += 3) {
         const start = rawClean.length - 3 - i < 0 ? 0 : rawClean.length - 3 - i
@@ -233,25 +306,23 @@ function format(rut: string, options?: FormatOptions): string | null {
       return result
     }
 
-    // For complete RUTs (8+ chars), add hyphen before verifier and dots
-    let result = rawClean.slice(-1) // Verifier digit
-    result = rawClean.slice(-4, -1) + '-' + result // 3 digits + hyphen + verifier
-
+    let result = rawClean.slice(-4, -1) + '-' + rawClean.slice(-1)
     for (let i = 4; i < rawClean.length; i += 3) {
       const start = rawClean.length - 3 - i < 0 ? 0 : rawClean.length - 3 - i
-      if (opts.dots) {
-        result = rawClean.slice(start, rawClean.length - i) + '.' + result
-      } else {
-        result = rawClean.slice(start, rawClean.length - i) + result
-      }
+      result = opts.dots
+        ? rawClean.slice(start, rawClean.length - i) + '.' + result
+        : rawClean.slice(start, rawClean.length - i) + result
     }
 
     return result
   }
 
-  // Non-incremental mode: validate length
   const cleanRut = clean(rut, withThrowOption(opts.throwOnError))
   if (cleanRut === null) return null
+
+  const body = cleanRut.slice(0, -1)
+  const verifier = cleanRut.slice(-1)
+  if (calculateVerifierForBody(body) !== verifier) return fail<string>(rut, opts.throwOnError)
 
   if (opts.dots) {
     let result = cleanRut.slice(-4, -1) + '-' + cleanRut.substring(cleanRut.length - 1)
@@ -265,11 +336,16 @@ function format(rut: string, options?: FormatOptions): string | null {
 
 /**
  * Generates a random valid RUT string.
+ * Uses Web Crypto when available, and falls back to Math.random in older runtimes.
  * @returns {string} A randomly generated, valid RUT string.
  */
 const generate = (): string => {
-  const body = Math.floor(10000003 + Math.random() * 90000000).toString()
-  const verifier = calculateVerifier(body)
+  let body = randomIntInclusive(MIN_GENERATED_BODY, MAX_GENERATED_BODY).toString()
+  while (isSuspicious(body)) {
+    body = randomIntInclusive(MIN_GENERATED_BODY, MAX_GENERATED_BODY).toString()
+  }
+
+  const verifier = calculateVerifierForBody(body)
   return format(body + verifier)
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,18 @@ const MIN_RUT_LENGTH = 8
 const MAX_RUT_LENGTH = 9
 const MIN_BODY_LENGTH = 7
 const MAX_BODY_LENGTH = 8
+/**
+ * Hard upper bound on accepted input length. This is a SECURITY bound, not a
+ * RUT format rule: a real RUT is ~9 significant chars (and ~12 with dots and a
+ * hyphen, a bit more with leading zeros or surrounding whitespace). The cap
+ * exists so an attacker cannot feed an arbitrarily long string into the
+ * validator and burn CPU — oversized input is rejected *before* any regex
+ * runs (defense in depth alongside the non-backtracking patterns). 64 is an
+ * arbitrary round number, generously above any legitimately-formatted RUT yet
+ * small enough that the bounded patterns can never see an attack string.
+ * Consequence: zero-padded inputs longer than 64 chars are rejected even
+ * though older versions normalized them — see CHANGELOG "Changed (Breaking)".
+ */
 const MAX_RUT_INPUT_LENGTH = 64
 const MIN_GENERATED_BODY = 10000000
 const MAX_GENERATED_BODY = 99999999

--- a/tests/calculateVerifier.test.ts
+++ b/tests/calculateVerifier.test.ts
@@ -61,6 +61,8 @@ describe('calculateVerifier', () => {
 
     test('throws error with non-numeric characters', () => {
       expect(() => calculateVerifier('abcdefgh')).toThrow()
+      expect(() => calculateVerifier('12abc345678')).toThrow()
+      expect(() => calculateVerifier('12#345#678')).toThrow()
     })
   })
 
@@ -73,6 +75,12 @@ describe('calculateVerifier', () => {
       expect(calculateVerifier('123', { throwOnError: false })).toBeNull()
       expect(calculateVerifier('12345', { throwOnError: false })).toBeNull()
       expect(calculateVerifier('12345678901', { throwOnError: false })).toBeNull()
+      expect(calculateVerifier('12abc345678', { throwOnError: false })).toBeNull()
+    })
+
+    test('returns null for non-string inputs', () => {
+      expect(calculateVerifier(12345678 as any, { throwOnError: false })).toBeNull()
+      expect(calculateVerifier(null as any, { throwOnError: false })).toBeNull()
     })
 
     test('returns verifier when valid', () => {

--- a/tests/clean.test.ts
+++ b/tests/clean.test.ts
@@ -23,6 +23,12 @@ describe('Test Suite: clean', () => {
       expect(clean('KK345678', { throwOnError: false })).toBeNull()
     })
 
+    test('Returns null for non-string inputs', () => {
+      expect(clean(123456789 as any, { throwOnError: false })).toBeNull()
+      expect(clean(null as any, { throwOnError: false })).toBeNull()
+      expect(clean(undefined as any, { throwOnError: false })).toBeNull()
+    })
+
     test('Returns cleaned RUT when valid', () => {
       expect(clean('12.345.678-k', { throwOnError: false })).toBe('12345678K')
       expect(clean('9.068.826-K', { throwOnError: false })).toBe('9068826K')
@@ -71,6 +77,11 @@ describe('Test Suite: clean', () => {
     test('Throws error with empty string', () => {
       expect(() => clean('')).toThrow()
       expect(() => clean('   ')).toThrow()
+    })
+
+    test('Throws a generic error without echoing the RUT value', () => {
+      expect(() => clean('123')).toThrow('Invalid RUT input')
+      expect(() => clean('123')).not.toThrow(/123/)
     })
 
     test('Throws error with RUTs that are too long or too short', () => {

--- a/tests/decompose.test.ts
+++ b/tests/decompose.test.ts
@@ -80,6 +80,11 @@ describe('decompose function', () => {
       expect(decompose('invalid', { throwOnError: false })).toBeNull()
     })
 
+    test('returns null for non-string inputs', () => {
+      expect(decompose(123456789 as any, { throwOnError: false })).toBeNull()
+      expect(decompose(null as any, { throwOnError: false })).toBeNull()
+    })
+
     test('returns decomposed RUT when valid', () => {
       expect(decompose('18.972.631-7', { throwOnError: false })).toEqual({ body: '18972631', verifier: '7' })
       expect(decompose('9.068.826-K', { throwOnError: false })).toEqual({ body: '9068826', verifier: 'K' })

--- a/tests/differential-report.md
+++ b/tests/differential-report.md
@@ -1,0 +1,36 @@
+# Differential report — v3.4.0 vs v4.0.0 `validate()`
+
+- Seed: `0x52555420` (reproducible)
+- Corpus size: **1,000,000**
+- Agree valid (`true/true`): **301,247**
+- Agree invalid (`false/false`): **623,670**
+- ⚠️ Regressions (was `true` → now `false`): **25,083**
+- New acceptances (was `false` → now `true`): **50,000**
+
+## ⚠️ Regressions by input shape (potential false negatives for a 3.x dataset)
+
+| Input shape | Count | Samples |
+|-------------|------:|---------|
+| `noncanonical-grouping` | 25082 | `19.872850-0`, `47.739439-6`, `57.903709-1`, `48.181835-4`, `77.697779-9`, `33.841571-0`, `54.040135-7`, `47.183067-4` |
+| `len-65-over-cap` | 1 | `0000000000000000000000000000000000000…` |
+
+## New acceptances by input shape
+
+| Input shape | Count | Samples |
+|-------------|------:|---------|
+| `surrounding-space` | 50000 | `  19.872.850-0  `, `  9.114.808-0  `, `  47.739.439-6  `, `  3.948.431-5  `, `  57.903.709-1  `, `  5.769.904-3  `, `  48.181.835-4  `, `  6.280.475-0  ` |
+
+## Security spot checks
+
+- `validate('8.888.888-K', { strict: true })` — v3.4.0: **true** (bug: should be false), v4.0.0: **false**
+- Non-string inputs with diverging result: **0** (none — both reject)
+- ReDoS: `validate('0'.repeat(100000) + 'x')` on v4.0.0 → **false** in **0.09 ms** (the frozen 3.4.0 regex exhibits catastrophic backtracking on this input and is deliberately not run here)
+
+## How to read this
+
+`generate()`/canonical inputs land in *Agree valid*. The **Regressions** table
+is the actionable part: every shape there is an input format that v3.4.0
+accepted and v4.0.0 now rejects. Confirm your production dataset uses **none**
+of those shapes (or normalize it to compact / compact+hyphen / canonical-dotted)
+before upgrading. This harness cannot prove safety on data it never saw — it
+enumerates exactly what changed.

--- a/tests/differential.test.ts
+++ b/tests/differential.test.ts
@@ -1,0 +1,364 @@
+/**
+ * Differential harness: v3.4.0 `validate()` vs v4.0.0 `validate()`.
+ *
+ * Goal: characterize EXACTLY which input shapes change their validation result
+ * between the last 3.x release and 4.0.0, so a large production dataset can be
+ * assessed for impact before upgrading.
+ *
+ * This is intentionally a single self-contained file: the project's jest
+ * `testRegex` matches every `*.ts` under `tests/`, so sibling helper modules
+ * would be picked up as (empty) suites and break `npm test`.
+ *
+ * Default `npm test` only runs a fast smoke check here. The full ~1M-case run
+ * is gated behind an env var:
+ *
+ *   npm run test:differential                  # 1,000,000 cases (default)
+ *   DIFF_CORPUS=200000 npm run test:differential
+ *
+ * It writes a human-readable report to `tests/differential-report.md`.
+ * The corpus is generated from a seeded PRNG, so runs are reproducible.
+ */
+
+import { writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { validate as validateV4 } from '../src/index'
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * FROZEN SNAPSHOT — rut.ts v3.4.0 `validate()` and its dependencies.
+ * Copied verbatim (behavior-preserving) from the 3.4.0 `src/index.ts`.
+ * DO NOT "improve" this code: its job is to reproduce 3.x behavior exactly.
+ * ──────────────────────────────────────────────────────────────────────────── */
+const legacyPatterns = {
+  cleaning: /^0+|[^0-9kK]+/g,
+  rutLike: /^0*(\d{1,3}(\.?\d{3})*)-?([\dkK])$/,
+  suspicious: /^(\d)\1?\.?(\1{3})\.?(\1{3})-?(\d|k)?$/,
+}
+
+const LEGACY_MIN = 8
+const LEGACY_MAX = 9
+
+const legacyCleanRaw = (rut: string): string => rut.replace(/^0+|[^0-9kK]+/g, '').toUpperCase()
+
+const legacyClean = (rut: string): string | null => {
+  const cleanRut = rut.replace(legacyPatterns.cleaning, '').toUpperCase()
+  if (cleanRut.length < LEGACY_MIN || cleanRut.length > LEGACY_MAX) return null
+  if (cleanRut.includes('K') && cleanRut.indexOf('K') !== cleanRut.length - 1) return null
+  return cleanRut
+}
+
+const legacyCalculateVerifier = (rutBody: string): string | null => {
+  const cleanedRut = legacyCleanRaw(rutBody)
+  if (cleanedRut.length < 7 || cleanedRut.length > 8) return null
+  if (!/^\d+$/.test(cleanedRut)) return null
+  const sum = cleanedRut
+    .split('')
+    .reverse()
+    .reduce((acc, digit, index) => acc + Number(digit) * ((index % 6) + 2), 0)
+  const checkDigit = 11 - (sum % 11)
+  return checkDigit === 11 ? '0' : checkDigit === 10 ? 'K' : checkDigit.toString()
+}
+
+const legacyValidate = (rut: unknown, options?: { strict?: boolean }): boolean => {
+  if (typeof rut !== 'string' || rut.length === 0) return false
+  if (!legacyPatterns.rutLike.test(rut)) return false
+  if (options?.strict && legacyPatterns.suspicious.test(rut)) return false
+
+  const cleaned = legacyClean(rut)
+  if (cleaned === null) return false
+  const body = cleaned.slice(0, -1)
+  const verifier = cleaned.slice(-1)
+
+  const calculated = legacyCalculateVerifier(body)
+  if (!calculated) return false
+  return calculated === verifier
+}
+/* ──────────────────────────── end frozen snapshot ─────────────────────────── */
+
+/** Deterministic PRNG (mulberry32) so the corpus and report are reproducible. */
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0
+  return () => {
+    a |= 0
+    a = (a + 0x6d2b79f5) | 0
+    let t = Math.imul(a ^ (a >>> 15), 1 | a)
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+const rand = mulberry32(0x52555420) // "RUT "
+const randInt = (min: number, max: number) => min + Math.floor(rand() * (max - min + 1))
+
+/** Modulo 11 — used only to build *known-valid* corpus rows. */
+function dvOf(body: string): string {
+  let sum = 0
+  let mul = 2
+  for (let i = body.length - 1; i >= 0; i--) {
+    sum += (body.charCodeAt(i) - 48) * mul
+    mul = mul === 7 ? 2 : mul + 1
+  }
+  const c = 11 - (sum % 11)
+  return c === 11 ? '0' : c === 10 ? 'K' : String(c)
+}
+
+function randomValidBody(): string {
+  // 7- or 8-digit body, never all-same-digit, no leading zero.
+  const len = rand() < 0.5 ? 7 : 8
+  let body = ''
+  do {
+    body = String(randInt(0, 9) || 1)
+    for (let i = 1; i < len; i++) body += String(randInt(0, 9))
+  } while (/^(.)\1*$/.test(body))
+  return body
+}
+
+type Row = { input: string; shape: string }
+
+/** Render a known-valid (body+dv) into one of many real-world shapes. */
+function renderShapes(body: string, dv: string): Row[] {
+  const compact = `${body}${dv}`
+  const dotted = (b: string) => {
+    // group from the right in 3s
+    const head = b.length === 8 ? b.slice(0, 2) : b.slice(0, 1)
+    const rest = b.length === 8 ? b.slice(2) : b.slice(1)
+    return `${head}.${rest.slice(0, 3)}.${rest.slice(3)}`
+  }
+  return [
+    { input: compact, shape: 'compact' },
+    { input: `${body}-${dv}`, shape: 'compact+hyphen' },
+    { input: `${dotted(body)}-${dv}`, shape: 'canonical-dotted' },
+    { input: `${dotted(body)}${dv}`, shape: 'dotted-no-hyphen' },
+    { input: `${compact.slice(0, -1)}${dv.toLowerCase()}`, shape: 'lowercase-k' },
+    { input: `00${compact}`, shape: 'leading-zeros' },
+    { input: `  ${dotted(body)}-${dv}  `, shape: 'surrounding-space' },
+    // ----- non-canonical: this is the regression surface -----
+    { input: `${body.slice(0, 2)}.${body.slice(2)}-${dv}`, shape: 'noncanonical-grouping' },
+    { input: `${body.split('').join('.')}-${dv}`, shape: 'every-digit-dotted' },
+    { input: `${body.split('').join(' ')} ${dv}`, shape: 'internal-spaces' },
+    { input: `${body.replace(/(\d{3})/g, '$1,')}${dv}`, shape: 'comma-separated' },
+  ]
+}
+
+const REPORT_PATH = join(__dirname, 'differential-report.md')
+
+function runDifferential(targetSize: number) {
+  const rows: Row[] = []
+
+  // Stratum A + B: known-valid bodies in many representations.
+  while (rows.length < targetSize * 0.55) {
+    const body = randomValidBody()
+    rows.push(...renderShapes(body, dvOf(body)))
+  }
+
+  // Stratum C: invalid — wrong DV, random noise, wrong length, garbage chars.
+  while (rows.length < targetSize * 0.9) {
+    const pick = rand()
+    if (pick < 0.4) {
+      const body = randomValidBody()
+      const good = dvOf(body)
+      let bad = String(randInt(0, 9))
+      while (bad === good) bad = randInt(0, 9) < 1 ? 'K' : String(randInt(0, 9))
+      rows.push({ input: `${body}-${bad}`, shape: 'invalid-wrong-dv' })
+    } else if (pick < 0.7) {
+      const n = randInt(1, 15)
+      let s = ''
+      for (let i = 0; i < n; i++) s += String(randInt(0, 9))
+      rows.push({ input: s, shape: 'random-digits' })
+    } else if (pick < 0.9) {
+      rows.push({ input: Math.random().toString(36).slice(2, 2 + randInt(3, 12)), shape: 'garbage' })
+    } else {
+      const body = randomValidBody()
+      rows.push({ input: `${body}${body}${dvOf(body)}`, shape: 'too-long' })
+    }
+  }
+
+  // Stratum D: targeted edges + the security cases. Each appears EXACTLY ONCE.
+  //
+  // IMPORTANT: the frozen 3.4.0 regex is ReDoS-vulnerable, so a long adversarial
+  // string must never be fed to `legacyValidate` more than a handful of times.
+  // We use a moderate-length adversarial row here (single occurrence) and prove
+  // the *real* 100k-char ReDoS fix as a v4-only timing assertion below — without
+  // ever running the vulnerable legacy regex on it.
+  const edges: Row[] = [
+    { input: '', shape: 'empty' },
+    { input: '   ', shape: 'whitespace-only' },
+    { input: '0'.repeat(4000) + 'x', shape: 'redos-adversarial-moderate' },
+    { input: '1'.repeat(20000), shape: 'huge-digits' },
+    { input: '0'.repeat(55) + '123456785', shape: 'len-64-padded-valid' },
+    { input: '0'.repeat(56) + '123456785', shape: 'len-65-over-cap' },
+  ]
+  for (const d of '0123456789') {
+    const b = d.repeat(8)
+    edges.push({ input: `${b}${dvOf(b)}`, shape: 'placeholder-repeated' })
+  }
+  rows.push(...edges)
+
+  // Pad to the target size with CHEAP invalid rows (short random digit strings),
+  // never by recycling the expensive edges above.
+  while (rows.length < targetSize) {
+    const n = randInt(1, 6)
+    let s = ''
+    for (let i = 0; i < n; i++) s += String(randInt(0, 9))
+    rows.push({ input: s, shape: 'pad-short-digits' })
+  }
+
+  // v4-only ReDoS proof: the genuine 100k-char attack string is NEVER passed to
+  // the vulnerable legacy regex — only to the hardened v4 validator.
+  const redosInput = '0'.repeat(100_000) + 'x'
+  const redosStart = performance.now()
+  const redosV4Result = validateV4(redosInput)
+  const redosV4Ms = performance.now() - redosStart
+
+  // ---- classify ----
+  let agreeTrue = 0
+  let agreeFalse = 0
+  const regressions = new Map<string, { count: number; samples: string[] }>() // old=true, new=false
+  const newAccepts = new Map<string, { count: number; samples: string[] }>() // old=false, new=true
+
+  const bump = (m: Map<string, { count: number; samples: string[] }>, shape: string, input: string) => {
+    const e = m.get(shape) ?? { count: 0, samples: [] }
+    e.count++
+    if (e.samples.length < 8) e.samples.push(input.length > 40 ? `${input.slice(0, 37)}…` : input)
+    m.set(shape, e)
+  }
+
+  for (const { input, shape } of rows) {
+    const o = legacyValidate(input)
+    const n = validateV4(input)
+    if (o && n) agreeTrue++
+    else if (!o && !n) agreeFalse++
+    else if (o && !n) bump(regressions, shape, input)
+    else bump(newAccepts, shape, input)
+  }
+
+  // Strict-mode security spot check (the uppercase-K bypass).
+  const strictBypassOld = legacyValidate('8.888.888-K', { strict: true })
+  const strictBypassNew = validateV4('8.888.888-K', { strict: true })
+
+  // Non-string inputs (kept out of the string corpus).
+  const nonStringRows = [null, undefined, 123456785, {}, [], NaN, true]
+  const nonStringDivergence = nonStringRows.filter(
+    (v) => legacyValidate(v as unknown) !== validateV4(v as unknown),
+  )
+
+  const total = rows.length
+  const regrTotal = [...regressions.values()].reduce((a, b) => a + b.count, 0)
+  const accTotal = [...newAccepts.values()].reduce((a, b) => a + b.count, 0)
+
+  const fmt = (m: Map<string, { count: number; samples: string[] }>) =>
+    [...m.entries()]
+      .sort((a, b) => b[1].count - a[1].count)
+      .map(([shape, e]) => `| \`${shape}\` | ${e.count} | ${e.samples.map((s) => `\`${s}\``).join(', ')} |`)
+      .join('\n') || '| _(none)_ | 0 | |'
+
+  const report = `# Differential report — v3.4.0 vs v4.0.0 \`validate()\`
+
+- Seed: \`0x52555420\` (reproducible)
+- Corpus size: **${total.toLocaleString('en-US')}**
+- Agree valid (\`true/true\`): **${agreeTrue.toLocaleString('en-US')}**
+- Agree invalid (\`false/false\`): **${agreeFalse.toLocaleString('en-US')}**
+- ⚠️ Regressions (was \`true\` → now \`false\`): **${regrTotal.toLocaleString('en-US')}**
+- New acceptances (was \`false\` → now \`true\`): **${accTotal.toLocaleString('en-US')}**
+
+## ⚠️ Regressions by input shape (potential false negatives for a 3.x dataset)
+
+| Input shape | Count | Samples |
+|-------------|------:|---------|
+${fmt(regressions)}
+
+## New acceptances by input shape
+
+| Input shape | Count | Samples |
+|-------------|------:|---------|
+${fmt(newAccepts)}
+
+## Security spot checks
+
+- \`validate('8.888.888-K', { strict: true })\` — v3.4.0: **${strictBypassOld}** (bug: should be false), v4.0.0: **${strictBypassNew}**
+- Non-string inputs with diverging result: **${nonStringDivergence.length}** ${
+    nonStringDivergence.length ? `(${nonStringDivergence.map(String).join(', ')})` : '(none — both reject)'
+  }
+- ReDoS: \`validate('0'.repeat(100000) + 'x')\` on v4.0.0 → **${redosV4Result}** in **${redosV4Ms.toFixed(2)} ms** (the frozen 3.4.0 regex exhibits catastrophic backtracking on this input and is deliberately not run here)
+
+## How to read this
+
+\`generate()\`/canonical inputs land in *Agree valid*. The **Regressions** table
+is the actionable part: every shape there is an input format that v3.4.0
+accepted and v4.0.0 now rejects. Confirm your production dataset uses **none**
+of those shapes (or normalize it to compact / compact+hyphen / canonical-dotted)
+before upgrading. This harness cannot prove safety on data it never saw — it
+enumerates exactly what changed.
+`
+
+  writeFileSync(REPORT_PATH, report)
+  return {
+    total,
+    agreeTrue,
+    agreeFalse,
+    regrTotal,
+    accTotal,
+    strictBypassOld,
+    strictBypassNew,
+    nonStringDivergence: nonStringDivergence.length,
+    redosV4Result,
+    redosV4Ms,
+    regressionShapes: [...regressions.keys()],
+    newAcceptShapes: [...newAccepts.keys()],
+  }
+}
+
+/* ──────────────────────────────────────────────────────────────────────────── */
+
+const FULL = process.env.RUN_DIFFERENTIAL === '1'
+const CORPUS = Number(process.env.DIFF_CORPUS ?? 1_000_000)
+
+;(FULL ? describe : describe.skip)('differential v3.4.0 vs v4.0.0 (full corpus)', () => {
+  jest.setTimeout(120_000)
+
+  const result = runDifferential(CORPUS)
+
+  test('canonical-valid inputs never regress (no false negatives on accepted shapes)', () => {
+    // Regressions are only allowed in shapes that v4.0.0 *intentionally and
+    // documentably* rejects (see CHANGELOG "Changed (Breaking)"):
+    //  - non-canonical dot grouping (#2)
+    //  - inputs longer than the 64-char cap (#2)
+    // The every-digit-dotted / internal-spaces / comma-separated shapes were
+    // already rejected by 3.4.0 too, so they must NOT appear here.
+    const allowed = new Set(['noncanonical-grouping', 'len-65-over-cap'])
+    const unexpected = result.regressionShapes.filter((s) => !allowed.has(s))
+    // eslint-disable-next-line no-console
+    console.log(JSON.stringify(result, null, 2))
+    expect(unexpected).toEqual([])
+  })
+
+  test('v4.0.0 introduces no surprising new acceptances', () => {
+    // The only relaxation is whitespace trimming around otherwise-valid input.
+    const allowed = new Set(['surrounding-space'])
+    const unexpected = result.newAcceptShapes.filter((s) => !allowed.has(s))
+    expect(unexpected).toEqual([])
+  })
+
+  test('strict uppercase-K bypass is fixed', () => {
+    expect(result.strictBypassOld).toBe(true) // the 3.x bug
+    expect(result.strictBypassNew).toBe(false) // fixed in 4.0.0
+  })
+
+  test('v4.0.0 is ReDoS-safe on a 100k-char adversarial input', () => {
+    expect(result.redosV4Result).toBe(false)
+    expect(result.redosV4Ms).toBeLessThan(50)
+  })
+
+  test('report written', () => {
+    expect(result.total).toBeGreaterThanOrEqual(CORPUS)
+  })
+})
+
+// Fast smoke check so the file is a valid suite under plain `npm test`.
+;(FULL ? describe.skip : describe)('differential (smoke)', () => {
+  test('legacy snapshot and v4 disagree exactly on a known non-canonical shape', () => {
+    expect(legacyValidate('12.345678-5')).toBe(true)
+    expect(validateV4('12.345678-5')).toBe(false)
+    expect(legacyValidate('12.345.678-5')).toBe(validateV4('12.345.678-5'))
+  })
+})

--- a/tests/format.test.ts
+++ b/tests/format.test.ts
@@ -21,6 +21,15 @@ describe('format', () => {
     test('Returns null for RUTs that are too long', () => {
       expect(format('12345678901', { throwOnError: false })).toBeNull()
     })
+
+    test('Returns null for RUTs with an incorrect verifier', () => {
+      expect(format('123456789', { throwOnError: false })).toBeNull()
+    })
+
+    test('Returns null for non-string inputs', () => {
+      expect(format(123456785 as any, { throwOnError: false })).toBeNull()
+      expect(format(null as any, { throwOnError: false })).toBeNull()
+    })
   })
 
   describe('incremental mode (progressive formatting)', () => {
@@ -67,8 +76,8 @@ describe('format', () => {
       expect(format('00012345678', { incremental: true })).toBe('1.234.567-8')
     })
 
-    test('Handles very long inputs (more than 9 digits)', () => {
-      expect(format('12345678901234', { incremental: true })).toBe('1.234.567.890.123-4')
+    test('Caps very long inputs to the maximum RUT length', () => {
+      expect(format('12345678901234', { incremental: true })).toBe('12.345.678-9')
     })
 
     test('Handles special characters in incremental mode', () => {
@@ -83,11 +92,11 @@ describe('format', () => {
     })
 
     test('Correctly formats with dots and hyphen', () => {
-      expect(format('123456789')).toBe('12.345.678-9')
+      expect(format('123456785')).toBe('12.345.678-5')
     })
 
     test('Correctly formats without dots', () => {
-      expect(format('123456789', { dots: false })).toBe('12345678-9')
+      expect(format('123456785', { dots: false })).toBe('12345678-5')
     })
 
     test('Returns empty string if input is empty', () => {
@@ -95,29 +104,33 @@ describe('format', () => {
     })
 
     test('Correctly handles RUTs with K as verification digit', () => {
-      expect(format('1234567K')).toBe('1.234.567-K')
+      expect(format('14625621k')).toBe('14.625.621-K')
       expect(format('09068826K')).toBe('9.068.826-K')
     })
 
     test('Correctly formats RUTs with leading zeros', () => {
-      expect(format('012345678')).toBe('1.234.567-8')
+      expect(format('0012345674')).toBe('1.234.567-4')
       expect(format('009068826K')).toBe('9.068.826-K')
     })
 
     test('Correctly handles RUTs with non-numeric characters', () => {
-      expect(format('12.345.678-k')).toBe('12.345.678-K')
-      expect(format('12#345#678#K')).toBe('12.345.678-K')
+      expect(format('14.625.621-k')).toBe('14.625.621-K')
+      expect(format('12#345#678#5')).toBe('12.345.678-5')
     })
 
     test('Correctly handles RUTs with white spaces', () => {
-      expect(format(' 123 456 789 ')).toBe('12.345.678-9')
+      expect(format(' 123 456 785 ')).toBe('12.345.678-5')
+    })
+
+    test('Throws for RUTs with an incorrect verifier', () => {
+      expect(() => format('123456789')).toThrow()
     })
   })
 
   describe('edge cases', () => {
     test('Formats 8-character RUTs (7 body + 1 verifier)', () => {
       expect(format('09068826K')).toBe('9.068.826-K')
-      expect(format('12345678')).toBe('1.234.567-8')
+      expect(format('12345674')).toBe('1.234.567-4')
     })
 
     test('Formats 9-character RUTs (8 body + 1 verifier)', () => {
@@ -126,7 +139,7 @@ describe('format', () => {
     })
 
     test('Formats with verifier 0', () => {
-      expect(format('182649580')).toBe('18.264.958-0')
+      expect(format('10000130')).toBe('1.000.013-0')
     })
 
     test('Already formatted RUTs remain unchanged', () => {
@@ -135,7 +148,7 @@ describe('format', () => {
     })
 
     test('Handles RUT with only hyphens as separators', () => {
-      expect(format('12-345-678-9')).toBe('12.345.678-9')
+      expect(format('12-345-678-5')).toBe('12.345.678-5')
     })
   })
 

--- a/tests/format.test.ts
+++ b/tests/format.test.ts
@@ -80,6 +80,18 @@ describe('format', () => {
       expect(format('12345678901234', { incremental: true })).toBe('12.345.678-9')
     })
 
+    test('Caps to 9 significant chars and drops a trailing K beyond the cap', () => {
+      // A trailing K is preserved only while the value still fits in 9 chars...
+      expect(format('123456785K', { incremental: true })).toBe('12.345.678-5')
+      expect(format('12.345.678-K', { incremental: true })).toBe('12.345.678-K')
+      // ...but once normalization yields >9 significant chars, the cap to
+      // MAX_RUT_LENGTH (9) keeps the first 9 digits and the K is dropped.
+      // This only affects live-typing display; final values must still be
+      // checked with `validate()`.
+      expect(format('1234567890K', { incremental: true })).toBe('12.345.678-9')
+      expect(format('12345678901234K', { incremental: true })).toBe('12.345.678-9')
+    })
+
     test('Handles special characters in incremental mode', () => {
       expect(format('12#34#56#78', { incremental: true })).toBe('1.234.567-8')
     })

--- a/tests/getBody.test.ts
+++ b/tests/getBody.test.ts
@@ -73,6 +73,11 @@ describe('getBody function', () => {
       expect(getBody('invalid', { throwOnError: false })).toBeNull()
     })
 
+    test('returns null for non-string inputs', () => {
+      expect(getBody(123456789 as any, { throwOnError: false })).toBeNull()
+      expect(getBody(null as any, { throwOnError: false })).toBeNull()
+    })
+
     test('returns body when valid', () => {
       expect(getBody('18.972.631-7', { throwOnError: false })).toBe('18972631')
       expect(getBody('9.068.826-K', { throwOnError: false })).toBe('9068826')

--- a/tests/getVerifier.test.ts
+++ b/tests/getVerifier.test.ts
@@ -97,6 +97,11 @@ describe('getVerifier function', () => {
       expect(getVerifier('invalid', { throwOnError: false })).toBeNull()
     })
 
+    test('returns null for non-string inputs', () => {
+      expect(getVerifier(123456789 as any, { throwOnError: false })).toBeNull()
+      expect(getVerifier(null as any, { throwOnError: false })).toBeNull()
+    })
+
     test('returns verifier when valid', () => {
       expect(getVerifier('23.579.222-2', { throwOnError: false })).toBe('2')
       expect(getVerifier('9.068.826-K', { throwOnError: false })).toBe('K')

--- a/tests/validate.test.ts
+++ b/tests/validate.test.ts
@@ -68,6 +68,8 @@ describe('validate', () => {
     test('invalidates RUT in incorrect format', () => {
       expect(validate('abcdefghi')).toBeFalsy()
       expect(validate('12,345,678-5')).toBeFalsy() // Commas not supported
+      expect(validate('12.345678-5')).toBeFalsy()
+      expect(validate('12345.678-5')).toBeFalsy()
     })
 
     test('invalidates empty RUT', () => {
@@ -82,6 +84,7 @@ describe('validate', () => {
       expect(validate('123')).toBeFalsy()
       expect(validate('1234567')).toBeFalsy()
       expect(validate('12345678901')).toBeFalsy()
+      expect(validate(`${'0'.repeat(128)}x`)).toBeFalsy()
     })
 
     test('invalidates RUT with K not at the end', () => {
@@ -100,6 +103,8 @@ describe('validate', () => {
       expect(validate('11.111.111-1', { strict: true })).toBeFalsy()
       expect(validate('22.222.222-2', { strict: true })).toBeFalsy()
       expect(validate('33.333.333-3', { strict: true })).toBeFalsy()
+      expect(validate('8.888.888-K', { strict: true })).toBeFalsy()
+      expect(validate('8888888K', { strict: true })).toBeFalsy()
     })
 
     test('validates suspicious RUT if strict is false or not provided', () => {
@@ -142,6 +147,9 @@ describe('isRutLike', () => {
     expect(isRutLike('abcdefghi')).toBeFalsy()
     expect(isRutLike('')).toBeFalsy()
     expect(isRutLike('12.34.56-7')).toBeFalsy()
+    expect(isRutLike('12.345678-5')).toBeFalsy()
+    expect(isRutLike('12345.678-5')).toBeFalsy()
+    expect(isRutLike('1'.repeat(128))).toBeFalsy()
   })
 
   test('Returns true for RUTs with leading zeros', () => {
@@ -150,6 +158,8 @@ describe('isRutLike', () => {
   })
 
   test('Returns false for non-string inputs', () => {
-    expect(isRutLike('' as any)).toBeFalsy()
+    expect(isRutLike(123456789 as any)).toBeFalsy()
+    expect(isRutLike(null as any)).toBeFalsy()
+    expect(isRutLike(undefined as any)).toBeFalsy()
   })
 })


### PR DESCRIPTION
## Summary

Security and correctness hardening of `rut.ts` for high-volume RUT/RUN identity validation in production. Originated from a strict production-readiness audit; this PR turns the findings into a real, verified change.

**Verdict from the audit:** the Modulo 11 algorithm itself is correct, but the input perimeter and the "clean / format / validate" semantics were the weak spots. This PR hardens them without removing the permissive normalization helpers that UIs rely on.

## Findings addressed

| # | Issue | Fix |
|---|-------|-----|
| 1 | **ReDoS / unbounded input.** `validate()`/`isRutLike()` ran an ambiguous regex before any length check. `"0".repeat(20000)+"x"` took ~580ms in the regex; `isRutLike("1".repeat(50000))` returned `true`. | Inputs are length-capped (`MAX_RUT_INPUT_LENGTH`) and matched against bounded, non-ambiguous shape patterns (compact / compact-with-hyphen / dotted) before any work. |
| 2 | **Over-permissive `clean()`/`format()`.** Unknown chars silently stripped; `format('123456789')` "fixed" the input to `12.345.678-9` despite a wrong verifier. | `clean()` rejects non-string/out-of-shape input. `format()` validates the verifier digit in non-incremental mode and returns `null`/throws for an incorrect DV. |
| 3 | **`strict` bypass with uppercase `K`.** `validate('8.888.888-K', { strict: true })` passed (suspicious regex only matched lowercase `k`). | Suspicious detection now runs on the cleaned body, uppercase-safe. |
| 4 | **`generate()` range bug.** `Math.floor(10000003 + random*90000000)` could emit 9-digit bodies that `calculateVerifier()` rejects; `Math.random()` presented as the only source. | Correct range `10000000–99999999`, draws from Web Crypto when available (`Math.random` fallback), skips repeated-digit placeholders. |
| 5 | **PII in error messages.** `getInvalidRutError()` echoed the full RUT into the message → ends up in logs/traces/alerts. | Generic message: `Invalid RUT input`. |
| 6 | **Safe mode not safe for JS callers.** `clean`/`format`/`calculateVerifier` threw `TypeError` on non-string input instead of returning `null`. | They now honor `throwOnError` for any invalid input type. |

Additionally, the verifier computation was rewritten without `split().reverse()` to cut allocations on the hot path (relevant when validating millions of values).

## Behavior changes (intentional, documented)

- `format()` in non-incremental mode no longer "repairs" a wrong verifier digit — it returns `null` (safe mode) or throws.
- `validate()` now rejects ambiguous dot grouping (e.g. `12.345678-5`, `12345.678-5`).
- `validate(..., { strict: true })` now correctly rejects uppercase-`K` repeated-digit placeholders.
- Error messages no longer contain the input value.

Docs (README + feature pages) updated in **English** to document the permissive-normalization vs strict-validation contract and the production guidance.

## Verification

- `npm test` → **8 suites / 175 tests pass** (extended with the bypass, bounded-input, non-string safe-mode, and `format()` DV cases).
- `npm run build` → passes (tsc ESM + CJS, terser minify).
- `npm run lint` → fails on a **pre-existing, unrelated** repo issue (ESLint 9 requires `eslint.config.*` but the repo still ships `.eslintrc`); intentionally not bundled into this security PR.

---

## Update — v4.0.0 finalization (post-review)

A thorough engineering review verified the audit empirically (reproduced the ReDoS, the `strict` uppercase-`K` bypass, the `isRutLike` 50k false-positive, and the `generate()` range bug) and confirmed the fixes are correct. The Modulo 11 algorithm and the `charCodeAt` hot-path rewrite are equivalent; measured throughput ≈ **9M `validate()`/sec** (1M mixed inputs in ~110 ms), ReDoS-safe.

The review found these are **breaking changes**, not a patch. This PR is therefore re-scoped as a **major release**:

- **`fix:` → `feat!:`** and **`package.json` bumped `3.4.0` → `4.0.0`** (versioning here is manual — no semantic-release; the `package.json` number is authoritative). Recommend **Squash & merge** so the `feat!` subject lands on `canary`.
- **`CHANGELOG.md` added** — starts at v4.0.0, enumerates every breaking change + a 3.x→4.0.0 migration guide.
- **Internal cleanup:** removed a dead post-`trim()` length re-check in `parseRutLike()` (unreachable after `isBoundedString`; whitespace-only case preserved). No behavior change. Documented in the changelog.
- **New regression test** pinning the incremental capping / trailing-`K` edge.
- **Docs fully updated:** version refs bumped everywhere (README badge, docs homepage hero, release banner, index callout); the accepted-format **validation contract** and **permissive-vs-strict** guidance documented; v4 non-string behavior noted on `decompose`/`getBody`/`getVerifier`.

### Differential evidence (3.4.0 vs 4.0.0)

Added a reproducible seeded harness — `tests/differential.test.ts`, run with `npm run test:differential` (gated; plain `npm test` stays fast). Over **1,000,000** stratified inputs comparing a frozen 3.4.0 `validate()` against 4.0.0:

| Bucket | Count | Meaning |
|---|---:|---|
| Agree valid | 301,247 | canonical forms — identical behavior |
| Agree invalid | 623,670 | identical behavior |
| **Regression (old `true` → new `false`)** | 25,083 | **25,082 = non-canonical dot grouping** (e.g. `19.872850-0`); 1 = >64-char input cap. Both are documented breaking changes. |
| New acceptance (old `false` → new `true`) | 50,000 | only surrounding-whitespace trim (documented relaxation) |

Security spot checks in-report: `strict` K-bypass fixed (`true`→`false`), 0 non-string divergence, 100k-char ReDoS input → `false` in **0.08 ms**. Report committed at `tests/differential-report.md`.

> ⚠️ **Production action for the ~10M dataset:** the harness cannot prove safety on data it never saw — it enumerates exactly what changed. Before deploying, confirm the client's RUTs do **not** use non-canonical single-dot grouping (or normalize them to compact / compact+hyphen / canonical-dotted first). Run `npm run test:differential` against a representative real sample.

### Verification

- `npm test` → **9 suites / 177 passed** (+5 gated differential tests skipped in the fast run).
- `npm run test:differential` → **5/5 passed** (1M corpus, ~3 s).
- `npm run build` → passes (tsc ESM + CJS + terser).
