### PR TITLE
test: comprehensive test-suite audit (v4) + sync docs to 394 tests

### DIFF
--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -7,7 +7,7 @@ Rut.ts provides a comprehensive set of utilities for working with Chilean RUTs -
 As of **v4.0.0** (a breaking release focused on production identity hardening), `validate()` and `isRutLike()` accept only three canonical shapes — compact (`123456785`), compact + hyphen (`12345678-5`), and canonical dotted (`12.345.678-5`, optionally with leading zeros and surrounding whitespace). Non-canonical dot grouping that 3.x tolerated is now rejected, input is capped at 64 characters as a security bound (not a format rule), and errors are a generic `Invalid RUT input` so Chilean ID values are never echoed into logs or traces. `clean()` and `decompose()` remain intentionally permissive for normalization and must not be treated as validation. Review the CHANGELOG before upgrading from 3.x.
 
 Key technical details:
-- **Size**: ~3KB minified, ~1.1KB gzipped
+- **Size**: ~3KB minified, ~1.4KB gzipped
 - **Zero dependencies**: Pure TypeScript implementation
 - **Safe mode**: All functions support `{ throwOnError: false }` to return `null` instead of throwing
 - **Dual package**: Native ESM with CommonJS fallback
@@ -47,7 +47,7 @@ Key technical details:
 
 ## Optional
 
-- [Testing Guide](https://rut.arrowsw.com/docs/testing): Information about the test suite with 182 tests covering all edge cases
+- [Testing Guide](https://rut.arrowsw.com/docs/testing): Information about the test suite with 394 tests covering all edge cases
 - [Contributing Guide](https://rut.arrowsw.com/docs/contributing): How to contribute to the project, development setup, and coding standards
 - [GitHub Issues](https://github.com/arrowsw/rut.ts/issues): Report bugs, request features, or ask questions
 - [Package Size Analysis](https://pkg-size.dev/rut.ts): Detailed breakdown of package size and bundle analysis

--- a/docs/src/app/page.jsx
+++ b/docs/src/app/page.jsx
@@ -5,45 +5,53 @@ import { exampleCode, installCode } from './constants/hero-page'
 
 export default function HomePage() {
   return (
-    <div style={{
-      minHeight: '100vh',
-      background: 'linear-gradient(to bottom, #000, #111, #000)',
-      color: 'white',
-      padding: '80px 24px'
-    }}>
+    <div
+      style={{
+        minHeight: '100vh',
+        background: 'linear-gradient(to bottom, #000, #111, #000)',
+        color: 'white',
+        padding: '80px 24px',
+      }}
+    >
       <div style={{ maxWidth: '1200px', margin: '0 auto', textAlign: 'center' }}>
         {/* Hero */}
         <div style={{ marginBottom: '60px' }}>
-          <div style={{
-            display: 'inline-block',
-            padding: '8px 16px',
-            background: 'rgba(255,255,255,0.05)',
-            border: '1px solid rgba(255,255,255,0.1)',
-            borderRadius: '20px',
-            marginBottom: '32px',
-            fontSize: '14px'
-          }}>
+          <div
+            style={{
+              display: 'inline-block',
+              padding: '8px 16px',
+              background: 'rgba(255,255,255,0.05)',
+              border: '1px solid rgba(255,255,255,0.1)',
+              borderRadius: '20px',
+              marginBottom: '32px',
+              fontSize: '14px',
+            }}
+          >
             <span style={{ color: '#10b981' }}>●</span> v4.0.0 — Production identity hardening
           </div>
 
-          <h1 style={{
-            fontSize: '96px',
-            fontWeight: 'bold',
-            marginBottom: '24px',
-            background: 'linear-gradient(to right, #fff, #aaa)',
-            WebkitBackgroundClip: 'text',
-            WebkitTextFillColor: 'transparent'
-          }}>
+          <h1
+            style={{
+              fontSize: '96px',
+              fontWeight: 'bold',
+              marginBottom: '24px',
+              background: 'linear-gradient(to right, #fff, #aaa)',
+              WebkitBackgroundClip: 'text',
+              WebkitTextFillColor: 'transparent',
+            }}
+          >
             rut<span style={{ color: '#666' }}>.ts</span>
           </h1>
 
-          <p style={{
-            fontSize: '32px',
-            color: '#999',
-            marginBottom: '48px',
-            maxWidth: '800px',
-            margin: '0 auto 48px'
-          }}>
+          <p
+            style={{
+              fontSize: '32px',
+              color: '#999',
+              marginBottom: '48px',
+              maxWidth: '800px',
+              margin: '0 auto 48px',
+            }}
+          >
             Handle Chilean RUT values with ease
           </p>
 
@@ -58,7 +66,7 @@ export default function HomePage() {
                 borderRadius: '12px',
                 fontWeight: '600',
                 textDecoration: 'none',
-                display: 'inline-block'
+                display: 'inline-block',
               }}
             >
               Get Started →
@@ -75,7 +83,7 @@ export default function HomePage() {
                 borderRadius: '12px',
                 fontWeight: '600',
                 textDecoration: 'none',
-                display: 'inline-block'
+                display: 'inline-block',
               }}
             >
               View on GitHub
@@ -83,16 +91,18 @@ export default function HomePage() {
           </div>
 
           {/* Code Example */}
-          <div style={{
-            maxWidth: '700px',
-            margin: '0 auto',
-            background: 'var(--code-bg)',
-            borderRadius: '16px',
-            textAlign: 'left',
-            position: 'relative',
-          }}>     
+          <div
+            style={{
+              maxWidth: '700px',
+              margin: '0 auto',
+              background: 'var(--code-bg)',
+              borderRadius: '16px',
+              textAlign: 'left',
+              position: 'relative',
+            }}
+          >
             <CodeBlock>
-              <CopyButton code={exampleCode}/>
+              <CopyButton code={exampleCode} />
               <span style={{ color: 'var(--code-keyword)' }}>import</span> {'{ '}
               <span style={{ color: 'var(--code-identifier)' }}>validate</span>,{' '}
               <span style={{ color: 'var(--code-identifier)' }}>format</span>
@@ -124,24 +134,29 @@ export default function HomePage() {
         </div>
 
         {/* Features */}
-        <div style={{
-          display: 'grid',
-          gridTemplateColumns: 'repeat(auto-fit, minmax(250px, 1fr))',
-          gap: '24px',
-          marginTop: '80px'
-        }}>
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns: 'repeat(auto-fit, minmax(250px, 1fr))',
+            gap: '24px',
+            marginTop: '80px',
+          }}
+        >
           {[
             { icon: '⚡', title: 'Lightning Fast', stat: '<1ms', label: 'execution time' },
-            { icon: '📦', title: 'Ultra Lightweight', stat: '~3KB', label: 'minified + gzipped' },
-            { icon: '🔧', title: '9 Core Functions', stat: '182', label: 'test cases' },
-            { icon: '🛡️', title: 'Type Safe', stat: '100%', label: 'type coverage' }
+            { icon: '📦', title: 'Ultra Lightweight', stat: '~3KB', label: '~1.4KB gzipped' },
+            { icon: '🔧', title: '9 Core Functions', stat: '394', label: 'test cases' },
+            { icon: '🛡️', title: 'Type Safe', stat: '100%', label: 'type coverage' },
           ].map((feature, i) => (
-            <div key={i} style={{
-              padding: '32px',
-              background: 'rgba(255,255,255,0.05)',
-              border: '1px solid rgba(255,255,255,0.1)',
-              borderRadius: '16px'
-            }}>
+            <div
+              key={i}
+              style={{
+                padding: '32px',
+                background: 'rgba(255,255,255,0.05)',
+                border: '1px solid rgba(255,255,255,0.1)',
+                borderRadius: '16px',
+              }}
+            >
               <div style={{ fontSize: '48px', marginBottom: '24px' }}>{feature.icon}</div>
               <div style={{ fontSize: '36px', fontWeight: 'bold', marginBottom: '8px' }}>{feature.stat}</div>
               <div style={{ fontSize: '12px', color: '#888', textTransform: 'uppercase', marginBottom: '16px' }}>
@@ -154,17 +169,20 @@ export default function HomePage() {
 
         {/* Installation */}
         <div style={{ marginTop: '120px' }}>
-          <h2 style={{ fontSize: '48px', fontWeight: 'bold', marginBottom: '32px' }}>
-            Ready to get started?
-          </h2>
-          <div style={{
-            background: 'var(--code-bg)',
-            borderRadius: '16px',
-            marginBottom: '32px',
-            position: 'relative',
-          }}>
-            
-            <CodeBlock><CopyButton code={installCode}/><span style={{ color: 'var(--code-function)', fontSize: '24px' }}>npm</span><span style={{ color: 'var(--code-string)', fontSize: '24px' }}> install rut.ts</span></CodeBlock>
+          <h2 style={{ fontSize: '48px', fontWeight: 'bold', marginBottom: '32px' }}>Ready to get started?</h2>
+          <div
+            style={{
+              background: 'var(--code-bg)',
+              borderRadius: '16px',
+              marginBottom: '32px',
+              position: 'relative',
+            }}
+          >
+            <CodeBlock>
+              <CopyButton code={installCode} />
+              <span style={{ color: 'var(--code-function)', fontSize: '24px' }}>npm</span>
+              <span style={{ color: 'var(--code-string)', fontSize: '24px' }}> install rut.ts</span>
+            </CodeBlock>
           </div>
           <Link
             href="/docs"
@@ -175,7 +193,7 @@ export default function HomePage() {
               borderRadius: '12px',
               fontWeight: '600',
               textDecoration: 'none',
-              display: 'inline-block'
+              display: 'inline-block',
             }}
           >
             Read the Documentation →
@@ -183,12 +201,14 @@ export default function HomePage() {
         </div>
 
         {/* Footer */}
-        <div style={{
-          marginTop: '120px',
-          paddingTop: '40px',
-          borderTop: '1px solid rgba(255,255,255,0.1)',
-          color: '#666'
-        }}>
+        <div
+          style={{
+            marginTop: '120px',
+            paddingTop: '40px',
+            borderTop: '1px solid rgba(255,255,255,0.1)',
+            color: '#666',
+          }}
+        >
           MIT © {new Date().getFullYear()} rut.ts by{' '}
           <a
             href="https://github.com/arrowsw"

--- a/docs/src/content/testing.mdx
+++ b/docs/src/content/testing.mdx
@@ -4,7 +4,7 @@ Rut.ts has comprehensive test coverage to ensure reliability.
 
 ## Test Suite
 
-The library is tested using [Jest](https://jestjs.io/) with 182 test cases covering all functions and edge cases.
+The library is tested using [Jest](https://jestjs.io/) with 394 test cases covering all functions and edge cases.
 
 ```bash
 npm test
@@ -12,8 +12,8 @@ npm test
 
 ## Coverage Statistics
 
-- **9 Test suites** (one per main function)
-- **182 Test cases** (comprehensive coverage)
+- **12 Test suites** (one per public function, plus differential, bundle smoke, and type-level suites)
+- **394 Test cases** (comprehensive coverage)
 - **100% Pass rate** ✅
 
 ## What's Tested
@@ -65,14 +65,18 @@ Tests are organized by function:
 
 ```
 tests/
-├── validate.test.ts      (25 tests)
-├── format.test.ts        (30 tests)
-├── clean.test.ts         (22 tests)
-├── getVerifier.test.ts   (22 tests)
-├── calculateVerifier.test.ts (19 tests)
-├── decompose.test.ts     (18 tests)
-├── getBody.test.ts       (18 tests)
-└── generate.test.ts      (12 tests)
+├── validate.test.ts            (93 tests)
+├── format.test.ts              (69 tests)
+├── clean.test.ts               (62 tests)
+├── calculateVerifier.test.ts   (47 tests)
+├── getVerifier.test.ts         (41 tests)
+├── getBody.test.ts             (29 tests)
+├── decompose.test.ts           (21 tests)
+├── generate.test.ts             (9 tests)
+├── getInvalidRutError.test.ts   (9 tests)
+├── differential.test.ts         (9 tests, opt-in via RUN_DIFFERENTIAL=1)
+├── dist.smoke.test.ts           (4 tests, runs against the built bundle)
+└── types.test.ts                (1 test, compile-time type assertions)
 ```
 
 Each test file includes:

--- a/llms.txt
+++ b/llms.txt
@@ -7,7 +7,7 @@ Rut.ts provides a comprehensive set of utilities for working with Chilean RUTs -
 As of **v4.0.0** (a breaking release focused on production identity hardening), `validate()` and `isRutLike()` accept only three canonical shapes — compact (`123456785`), compact + hyphen (`12345678-5`), and canonical dotted (`12.345.678-5`, optionally with leading zeros and surrounding whitespace). Non-canonical dot grouping that 3.x tolerated is now rejected, input is capped at 64 characters as a security bound (not a format rule), and errors are a generic `Invalid RUT input` so Chilean ID values are never echoed into logs or traces. `clean()` and `decompose()` remain intentionally permissive for normalization and must not be treated as validation. Review the CHANGELOG before upgrading from 3.x.
 
 Key technical details:
-- **Size**: ~3KB minified, ~1.1KB gzipped
+- **Size**: ~3KB minified, ~1.4KB gzipped
 - **Zero dependencies**: Pure TypeScript implementation
 - **Safe mode**: All functions support `{ throwOnError: false }` to return `null` instead of throwing
 - **Dual package**: Native ESM with CommonJS fallback
@@ -47,7 +47,7 @@ Key technical details:
 
 ## Optional
 
-- [Testing Guide](https://rut.arrowsw.com/docs/testing): Information about the test suite with 182 tests covering all edge cases
+- [Testing Guide](https://rut.arrowsw.com/docs/testing): Information about the test suite with 394 tests covering all edge cases
 - [Contributing Guide](https://rut.arrowsw.com/docs/contributing): How to contribute to the project, development setup, and coding standards
 - [GitHub Issues](https://github.com/arrowsw/rut.ts/issues): Report bugs, request features, or ask questions
 - [Package Size Analysis](https://pkg-size.dev/rut.ts): Detailed breakdown of package size and bundle analysis

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "eslint-plugin-prettier": "5.5.5",
         "eslint-plugin-react": "7.37.5",
         "eslint-plugin-react-hooks": "7.0.1",
+        "expect-type": "1.3.0",
         "jest": "30.2.0",
         "prettier": "3.8.1",
         "terser": "5.46.0",
@@ -4480,6 +4481,16 @@
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/expect/node_modules/jest-util": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "eslint-plugin-prettier": "5.5.5",
     "eslint-plugin-react": "7.37.5",
     "eslint-plugin-react-hooks": "7.0.1",
+    "expect-type": "1.3.0",
     "jest": "30.2.0",
     "prettier": "3.8.1",
     "terser": "5.46.0",

--- a/tests/calculateVerifier.test.ts
+++ b/tests/calculateVerifier.test.ts
@@ -1,118 +1,111 @@
-import { calculateVerifier } from '../src'
+import { calculateVerifier, decompose, format, generate, getBody, getVerifier, validate } from '../src'
 
 describe('calculateVerifier', () => {
-  describe('correct verifier calculations', () => {
-    test('should return the correct verifier digit for a given RUT body', () => {
-      expect(calculateVerifier('18264958')).toBe('9')
-      expect(calculateVerifier('18722009')).toBe('2')
-      expect(calculateVerifier('12345678')).toBe('5')
-    })
-
-    test('correctly calculates when verifier is K', () => {
-      expect(calculateVerifier('24657622')).toBe('K')
-      expect(calculateVerifier('14625621')).toBe('K')
-    })
-
-    test('correctly calculates verifier for 8-digit bodies', () => {
-      expect(calculateVerifier('18264958')).toBe('9')
-      expect(calculateVerifier('10000000')).toBe('8')
-      expect(calculateVerifier('18972631')).toBe('7')
-    })
-
-    test('handles formatted input (dots and hyphens are removed)', () => {
-      expect(calculateVerifier('18.264.958')).toBe('9')
-      expect(calculateVerifier('18-264-958')).toBe('9')
-    })
-
-    test('handles leading zeros (that result in 8-digit body after cleaning)', () => {
-      expect(calculateVerifier('018972631')).toBe('7') // Becomes 18972631 (8 digits)
-      expect(calculateVerifier('0018264958')).toBe('9') // Becomes 18264958 (8 digits)
+  describe('full Modulo-11 image (every possible output)', () => {
+    // Smallest 8-digit body producing each of the 11 possible verifier outputs.
+    // Computed from the canonical algorithm and pinned here so any future
+    // refactor of the Modulo-11 hot path is caught immediately.
+    test.each([
+      ['10000004', '0'],
+      ['10000009', '1'],
+      ['10000003', '2'],
+      ['10000008', '3'],
+      ['10000002', '4'],
+      ['10000007', '5'],
+      ['10000001', '6'],
+      ['10000006', '7'],
+      ['10000000', '8'],
+      ['10000005', '9'],
+      ['10000013', 'K'],
+    ])('calculateVerifier(%p) === %p', (body, expected) => {
+      expect(calculateVerifier(body)).toBe(expected)
     })
   })
 
-  describe('verifier digit range', () => {
-    test('verifier can be any digit from 0-9', () => {
-      expect(calculateVerifier('11111111')).toBe('1')
-      expect(calculateVerifier('18722009')).toBe('2')
-      expect(calculateVerifier('14745562')).toBe('3')
-      expect(calculateVerifier('23579222')).toBe('2')
-      expect(calculateVerifier('12345678')).toBe('5')
-    })
-
-    test('verifier can be K (10)', () => {
-      expect(calculateVerifier('24657622')).toBe('K')
-      expect(calculateVerifier('14625621')).toBe('K')
-    })
-  })
-
-  describe('error cases', () => {
-    test('throws error with empty string', () => {
-      expect(() => calculateVerifier('')).toThrow()
-    })
-
-    test('throws error with too short body', () => {
-      expect(() => calculateVerifier('123')).toThrow()
-      expect(() => calculateVerifier('12345')).toThrow()
-    })
-
-    test('throws error with too long body', () => {
-      expect(() => calculateVerifier('12345678901')).toThrow()
-    })
-
-    test('throws error with non-numeric characters', () => {
-      expect(() => calculateVerifier('abcdefgh')).toThrow()
-      expect(() => calculateVerifier('12abc345678')).toThrow()
-      expect(() => calculateVerifier('12#345#678')).toThrow()
+  describe('input normalization', () => {
+    test.each([
+      ['18264958', '9', '8-digit body'],
+      ['18722009', '2', '8-digit body'],
+      ['12345678', '5', '8-digit body'],
+      ['18972631', '7', '8-digit body'],
+      ['24657622', 'K', '8-digit body, K output'],
+      ['14625621', 'K', '8-digit body, K output'],
+      ['18.264.958', '9', 'formatted with dots'],
+      ['18-264-958', '9', 'with extra hyphens'],
+      ['018972631', '7', 'leading-zero strip → 8-digit'],
+      ['0018264958', '9', 'leading-zero strip → 8-digit'],
+      ['10000000', '8', 'minimum 8-digit body'],
+      ['99999999', '9', 'maximum 8-digit body'],
+    ])('calculateVerifier(%p) === %p (%s)', (body, expected, _label) => {
+      expect(calculateVerifier(body)).toBe(expected)
     })
   })
 
-  describe('with throwOnError: false (safe mode)', () => {
-    test('returns null for empty string instead of throwing', () => {
-      expect(calculateVerifier('', { throwOnError: false })).toBeNull()
-    })
+  describe('error mode', () => {
+    test.each([[''], ['123'], ['12345'], ['12345678901'], ['abcdefgh'], ['12abc345678'], ['12#345#678']])(
+      'throws for invalid input: %p',
+      (input) => {
+        expect(() => calculateVerifier(input)).toThrow('Invalid RUT input')
+      },
+    )
 
-    test('returns null for invalid RUT body', () => {
-      expect(calculateVerifier('123', { throwOnError: false })).toBeNull()
-      expect(calculateVerifier('12345', { throwOnError: false })).toBeNull()
-      expect(calculateVerifier('12345678901', { throwOnError: false })).toBeNull()
-      expect(calculateVerifier('12abc345678', { throwOnError: false })).toBeNull()
-    })
-
-    test('returns null for non-string inputs', () => {
-      expect(calculateVerifier(12345678 as any, { throwOnError: false })).toBeNull()
-      expect(calculateVerifier(null as any, { throwOnError: false })).toBeNull()
-    })
-
-    test('returns verifier when valid', () => {
-      expect(calculateVerifier('12345678', { throwOnError: false })).toBe('5')
-      expect(calculateVerifier('24657622', { throwOnError: false })).toBe('K')
-    })
-
-    test('handles formatted input in safe mode', () => {
-      expect(calculateVerifier('18.264.958', { throwOnError: false })).toBe('9')
+    test('throws when leading-zero strip leaves a body that is too short', () => {
+      expect(() => calculateVerifier('0000000')).toThrow('Invalid RUT input')
+      expect(() => calculateVerifier('000000')).toThrow('Invalid RUT input')
     })
   })
 
-  describe('edge cases', () => {
-    test('handles leading zeros (resulting in 8-digit body)', () => {
-      expect(calculateVerifier('018972631')).toBe('7')
-      expect(calculateVerifier('0018264958')).toBe('9')
+  describe('safe mode (throwOnError: false)', () => {
+    test.each([
+      [''],
+      ['123'],
+      ['12345'],
+      ['12345678901'],
+      ['12abc345678'],
+      ['0000000'], // leading-zero strip leaves nothing — covers the body-length floor
+    ])('returns null for invalid input: %p', (input) => {
+      expect(calculateVerifier(input, { throwOnError: false })).toBeNull()
     })
 
-    test('handles minimum valid body (8 digits)', () => {
-      expect(calculateVerifier('10000000')).toBe('8')
-      expect(calculateVerifier('10000002')).toBe('4')
+    test.each([[12345678], [null], [undefined], [{}], [Symbol('rut')]])(
+      'returns null for non-string input: %p',
+      (value) => {
+        expect(calculateVerifier(value as unknown as string, { throwOnError: false })).toBeNull()
+      },
+    )
+
+    test.each([
+      ['12345678', '5'],
+      ['24657622', 'K'],
+      ['18.264.958', '9'],
+    ])('returns verifier for valid input: %p → %p', (body, expected) => {
+      expect(calculateVerifier(body, { throwOnError: false })).toBe(expected)
+    })
+  })
+
+  describe('cross-function consistency (property)', () => {
+    // Strongest oracle: the math of `calculateVerifier` must agree with the
+    // verifier carried inside any RUT that `generate()` produced. This catches
+    // any divergence between the hot-path Modulo-11 sum and the rest of the
+    // library without needing to enumerate inputs by hand.
+    test('agrees with decompose+validate on 200 generated RUTs', () => {
+      for (let i = 0; i < 200; i++) {
+        const rut = generate()
+        const { body, verifier } = decompose(rut)
+        expect(calculateVerifier(body)).toBe(verifier)
+        // Also verify that a body+computed-verifier still passes validate.
+        expect(validate(body + calculateVerifier(body))).toBe(true)
+      }
     })
 
-    test('handles maximum valid body (8 digits)', () => {
-      expect(calculateVerifier('99999999')).toBe('9')
-    })
-
-    test('verifier algorithm is deterministic', () => {
-      const body = '12345678'
-      const verifier1 = calculateVerifier(body)
-      const verifier2 = calculateVerifier(body)
-      expect(verifier1).toBe(verifier2)
+    test('agrees with getBody + getVerifier on canonical inputs', () => {
+      for (const rut of ['18.972.631-7', '9.068.826-K', '14.625.621-k', '99.999.999-9']) {
+        const body = getBody(rut)
+        const verifier = getVerifier(rut)
+        expect(calculateVerifier(body)).toBe(verifier)
+        // And the round-trip through format produces canonical form.
+        expect(format(body + verifier)).toBe(format(rut))
+      }
     })
   })
 })

--- a/tests/clean.test.ts
+++ b/tests/clean.test.ts
@@ -1,138 +1,131 @@
 import { clean } from '../src'
 
-describe('Test Suite: clean', () => {
-  describe('with throwOnError: false (safe mode)', () => {
-    test('Returns null for empty string instead of throwing', () => {
-      expect(clean('', { throwOnError: false })).toBeNull()
-    })
-
-    test('Returns null for RUTs that are too short', () => {
-      expect(clean('1.2.34-K', { throwOnError: false })).toBeNull()
-      expect(clean('123', { throwOnError: false })).toBeNull()
-      expect(clean('1234567', { throwOnError: false })).toBeNull()
-    })
-
-    test('Returns null for RUTs that are too long', () => {
-      expect(clean('12.345.6789012-3', { throwOnError: false })).toBeNull()
-      expect(clean('12345678901', { throwOnError: false })).toBeNull()
-    })
-
-    test('Returns null for RUTs with K not at the end', () => {
-      expect(clean('K1234567', { throwOnError: false })).toBeNull()
-      expect(clean('1234K567', { throwOnError: false })).toBeNull()
-      expect(clean('KK345678', { throwOnError: false })).toBeNull()
-    })
-
-    test('Returns null for non-string inputs', () => {
-      expect(clean(123456789 as any, { throwOnError: false })).toBeNull()
-      expect(clean(null as any, { throwOnError: false })).toBeNull()
-      expect(clean(undefined as any, { throwOnError: false })).toBeNull()
-    })
-
-    test('Returns cleaned RUT when valid', () => {
-      expect(clean('12.345.678-k', { throwOnError: false })).toBe('12345678K')
-      expect(clean('9.068.826-K', { throwOnError: false })).toBe('9068826K')
+describe('clean', () => {
+  describe('happy path — permissive normalization', () => {
+    // `clean()` is intentionally permissive: it strips non-[0-9kK], leading
+    // zeros, and uppercases. It does NOT validate the verifier digit — that
+    // is `validate()`'s job. These cases document the normalization contract.
+    test.each([
+      ['12.345.678-k', '12345678K', 'canonical dotted, lowercase k'],
+      ['12.345.678-K', '12345678K', 'canonical dotted, uppercase K'],
+      ['0000012.345.678-K', '12345678K', 'many leading zeros'],
+      ['00009.068.826-K', '9068826K', '7-digit body + leading zeros'],
+      ['00000012345678K', '12345678K', 'compact + many leading zeros'],
+      ['123456789', '123456789', 'compact already-clean numeric'],
+      ['12345678K', '12345678K', 'compact already-clean with K'],
+      [' 12 345 6 78 - 9 ', '123456789', 'whitespace + hyphens scattered'],
+      ['   12345678K   ', '12345678K', 'surrounding whitespace'],
+      ['12-34-56-789', '123456789', 'extra hyphens'],
+      ['12-345-678-K', '12345678K', 'extra hyphens with K'],
+      ['12#34%56&@78K', '12345678K', 'special characters interleaved'],
+      ['12.345.678@#$-K', '12345678K', 'trailing garbage before verifier'],
+      ['12345678#', '12345678', 'trailing garbage stripped'],
+      ['12345678K###', '12345678K', 'trailing garbage after K'],
+      ['(12.345.678-K)', '12345678K', 'parentheses around RUT'],
+      ['12.345.678.K', '12345678K', 'dot before verifier'],
+      ['9068826k', '9068826K', 'compact lowercase k uppercased'],
+      ['10000002', '10000002', 'minimum-length 8-digit numeric'],
+      ['999999996', '999999996', 'maximum-length 9-char numeric'],
+    ])('clean(%p) === %p (%s)', (input, expected, _label) => {
+      expect(clean(input)).toBe(expected)
     })
   })
 
-  describe('basic cleaning', () => {
-    test('Removes non-numeric characters except K, and converts to uppercase', () => {
-      expect(clean('12.345.678-k')).toBe('12345678K')
-      expect(clean('12.345.678-K')).toBe('12345678K')
+  describe('safe mode — returns null instead of throwing', () => {
+    test.each([
+      ['', 'empty'],
+      ['   ', 'whitespace only'],
+      ['1.2.34-K', 'too short after normalization'],
+      ['123', 'too short'],
+      ['1234567', '7 chars (under MIN_RUT_LENGTH)'],
+      ['12.345.6789012-3', 'too long after normalization'],
+      ['12345678901', '11 chars (over MAX_RUT_LENGTH)'],
+      ['K1234567', 'K not at the end (leading)'],
+      ['1234K567', 'K in the middle'],
+      ['KK345678', 'multiple K'],
+      ['1234567KK', 'trailing multiple K'],
+      ['####', 'only invalid characters'],
+      ['abcdefgh', 'only alphabetic'],
+      ['--------', 'only separators'],
+    ])('returns null for invalid input: %p (%s)', (input, _label) => {
+      expect(clean(input, { throwOnError: false })).toBeNull()
     })
 
-    test('Removes leading zeros', () => {
-      expect(clean('0000012.345.678-K')).toBe('12345678K')
-      expect(clean('00009.068.826-K')).toBe('9068826K')
-      expect(clean('00000012345678K')).toBe('12345678K')
+    test.each([
+      [123456789, 'number'],
+      [null, 'null'],
+      [undefined, 'undefined'],
+      [{}, 'object'],
+      [Symbol('rut'), 'symbol'],
+    ])('returns null for non-string input: %p (%s)', (value, _label) => {
+      expect(clean(value as unknown as string, { throwOnError: false })).toBeNull()
     })
 
-    test('Keeps the RUT clean if it is already in the correct format', () => {
-      expect(clean('123456789')).toBe('123456789')
-      expect(clean('12345678K')).toBe('12345678K')
-    })
-
-    test('Removes white spaces', () => {
-      expect(clean(' 12 345 6 78 - 9 ')).toBe('123456789')
-      expect(clean('   12345678K   ')).toBe('12345678K')
-    })
-
-    test('Removes additional hyphens', () => {
-      expect(clean('12-34-56-789')).toBe('123456789')
-      expect(clean('12-345-678-K')).toBe('12345678K')
-    })
-
-    test('Removes special characters', () => {
-      expect(clean('12#34%56&@78K')).toBe('12345678K')
-      expect(clean('12.345.678@#$-K')).toBe('12345678K')
-    })
-
-    test('Cleans even if the RUT ends in invalid characters', () => {
-      expect(clean('12345678#')).toBe('12345678')
-      expect(clean('12345678K###')).toBe('12345678K')
+    test.each([
+      ['12.345.678-k', '12345678K'],
+      ['9.068.826-K', '9068826K'],
+      ['189726317', '189726317'],
+    ])('returns cleaned value for valid input: %p → %p', (input, expected) => {
+      expect(clean(input, { throwOnError: false })).toBe(expected)
     })
   })
 
-  describe('error cases', () => {
-    test('Throws error with empty string', () => {
-      expect(() => clean('')).toThrow()
-      expect(() => clean('   ')).toThrow()
-    })
-
-    test('Throws a generic error without echoing the RUT value', () => {
+  describe('error mode (default — throwOnError defaults to true)', () => {
+    test('throws a generic error message that never echoes the input (PII protection)', () => {
+      // Regression test for v4 breaking change #4 / security item #3:
+      // the message must be the constant 'Invalid RUT input'.
       expect(() => clean('123')).toThrow('Invalid RUT input')
       expect(() => clean('123')).not.toThrow(/123/)
+      expect(() => clean('secret-rut-leak')).toThrow('Invalid RUT input')
+      expect(() => clean('secret-rut-leak')).not.toThrow(/secret|leak/)
     })
 
-    test('Throws error with RUTs that are too long or too short', () => {
-      expect(() => clean('1.2.34-K')).toThrow()
-      expect(() => clean('12.345.6789012-3')).toThrow()
-      expect(() => clean('1234567')).toThrow()
-      expect(() => clean('12345678901')).toThrow()
+    test.each([
+      [''],
+      ['   '],
+      ['1.2.34-K'],
+      ['12.345.6789012-3'],
+      ['1234567'],
+      ['12345678901'],
+      ['K1234567'],
+      ['1234K567'],
+      ['1234567KK'],
+      ['####'],
+      ['abcdefgh'],
+    ])('throws for invalid input: %p', (input) => {
+      expect(() => clean(input)).toThrow('Invalid RUT input')
     })
 
-    test('Throws error with RUTs that have the letter K not at the end', () => {
-      expect(() => clean('K1234567')).toThrow()
-      expect(() => clean('1234K567')).toThrow()
-      expect(() => clean('12K45678')).toThrow()
+    test('does not throw for the minimum and maximum lengths after normalization', () => {
       expect(() => clean('1234567K')).not.toThrow()
       expect(() => clean('12345678K')).not.toThrow()
     })
+  })
 
-    test('Throws error if only invalid characters are included', () => {
-      expect(() => clean('####')).toThrow()
-      expect(() => clean('abcdefgh')).toThrow()
-      expect(() => clean('--------')).toThrow()
+  describe('security — MAX_RUT_INPUT_LENGTH (64) cap', () => {
+    test('accepts input padded to exactly 64 chars', () => {
+      const padded = '0'.repeat(55) + '123456785'
+      expect(padded.length).toBe(64)
+      expect(clean(padded)).toBe('123456785')
     })
 
-    test('Throws error for multiple K letters', () => {
-      expect(() => clean('1234567KK')).toThrow()
-      expect(() => clean('KK345678')).toThrow()
+    test('rejects input at 65 chars (over the cap)', () => {
+      const overCap = '0'.repeat(56) + '123456785'
+      expect(overCap.length).toBe(65)
+      expect(clean(overCap, { throwOnError: false })).toBeNull()
+      expect(() => clean(overCap)).toThrow('Invalid RUT input')
     })
   })
 
-  describe('edge cases', () => {
-    test('Handles lowercase k correctly', () => {
-      expect(clean('12345678k')).toBe('12345678K')
-      expect(clean('9068826k')).toBe('9068826K')
-    })
-
-    test('Handles minimum length RUT (8 chars)', () => {
-      expect(clean('9068826K')).toBe('9068826K')
-      expect(clean('10000002')).toBe('10000002')
-    })
-
-    test('Handles maximum length RUT (9 chars)', () => {
-      expect(clean('999999996')).toBe('999999996')
-      expect(clean('189726317')).toBe('189726317')
-    })
-
-    test('Handles RUTs with only dots', () => {
-      expect(clean('12.345.678.K')).toBe('12345678K')
-    })
-
-    test('Handles RUTs with parentheses', () => {
-      expect(clean('(12.345.678-K)')).toBe('12345678K')
-    })
+  describe('idempotency', () => {
+    // Normalization should be a fixed point on its own output. Detects any
+    // drift introduced by future refactors of the normalization helpers.
+    test.each(['12.345.678-5', '14.625.621-k', '009.068.826-K', ' 12 345 6 78 - 9 ', '(18.972.631-7)'])(
+      'clean(clean(%p)) === clean(%p)',
+      (input) => {
+        const once = clean(input)
+        expect(clean(once)).toBe(once)
+      },
+    )
   })
 })

--- a/tests/decompose.test.ts
+++ b/tests/decompose.test.ts
@@ -1,107 +1,66 @@
-import { decompose } from '../src'
+import { clean, decompose, getBody, getVerifier } from '../src'
 
-describe('decompose function', () => {
-  describe('basic decomposition', () => {
-    test('should return the body and verifier of a RUT', () => {
-      expect(decompose('18.972.631-7')).toEqual({ body: '18972631', verifier: '7' })
-    })
-
-    test('decomposes RUT with K verifier', () => {
-      expect(decompose('9.068.826-K')).toEqual({ body: '9068826', verifier: 'K' })
-      expect(decompose('14.625.621-k')).toEqual({ body: '14625621', verifier: 'K' })
-    })
-
-    test('decomposes RUT without dots', () => {
-      expect(decompose('18972631-7')).toEqual({ body: '18972631', verifier: '7' })
-      expect(decompose('9068826K')).toEqual({ body: '9068826', verifier: 'K' })
-    })
-
-    test('decomposes RUT without hyphen', () => {
-      expect(decompose('189726317')).toEqual({ body: '18972631', verifier: '7' })
-      expect(decompose('12345678K')).toEqual({ body: '12345678', verifier: 'K' })
-    })
-  })
-
-  describe('various formats', () => {
-    test('handles RUT with leading zeros', () => {
-      expect(decompose('009.068.826-K')).toEqual({ body: '9068826', verifier: 'K' })
-      expect(decompose('0018972631-7')).toEqual({ body: '18972631', verifier: '7' })
-    })
-
-    test('handles RUT with extra characters', () => {
-      expect(decompose('  18.972.631-7  ')).toEqual({ body: '18972631', verifier: '7' })
-      expect(decompose('(18.972.631-7)')).toEqual({ body: '18972631', verifier: '7' })
+/**
+ * `decompose` is a thin composition: `{ body: getBody(rut), verifier: getVerifier(rut) }`.
+ * Heavy parsing edge cases live in `clean.test.ts` / `getBody.test.ts` /
+ * `getVerifier.test.ts`. This file covers only what is unique to `decompose`:
+ *
+ * 1. the returned object shape
+ * 2. safe-mode null contract
+ * 3. generic error message (no PII echoing)
+ * 4. consistency with the underlying getBody / getVerifier wrappers
+ */
+describe('decompose', () => {
+  describe('returned shape', () => {
+    test.each([
+      ['18.972.631-7', { body: '18972631', verifier: '7' }],
+      ['9.068.826-K', { body: '9068826', verifier: 'K' }],
+      ['14.625.621-k', { body: '14625621', verifier: 'K' }],
+      ['18.264.159-0', { body: '18264159', verifier: '0' }],
+    ])('decompose(%p) === %j', (rut, expected) => {
+      expect(decompose(rut)).toEqual(expected)
     })
   })
 
-  describe('verifier types', () => {
-    test('decomposes RUT with numeric verifier', () => {
-      expect(decompose('18.972.631-7')).toEqual({ body: '18972631', verifier: '7' })
-      expect(decompose('18.264.159-0')).toEqual({ body: '18264159', verifier: '0' })
+  describe('safe mode (throwOnError: false)', () => {
+    test.each([
+      ['', 'empty'],
+      ['123', 'too short'],
+      ['invalid', 'non-numeric'],
+    ])('returns null for invalid input: %p (%s)', (input, _label) => {
+      expect(decompose(input, { throwOnError: false })).toBeNull()
     })
 
-    test('decomposes RUT with K verifier (uppercase and lowercase)', () => {
-      expect(decompose('9.068.826-K')).toEqual({ body: '9068826', verifier: 'K' })
-      expect(decompose('9.068.826-k')).toEqual({ body: '9068826', verifier: 'K' })
-    })
-  })
-
-  describe('length variations', () => {
-    test('decomposes 8-digit RUTs', () => {
-      expect(decompose('9.068.826-K')).toEqual({ body: '9068826', verifier: 'K' })
+    test.each([[123456789], [null], [undefined], [{}]])('returns null for non-string input: %p', (value) => {
+      expect(decompose(value as unknown as string, { throwOnError: false })).toBeNull()
     })
 
-    test('decomposes 9-digit RUTs', () => {
-      expect(decompose('18.972.631-7')).toEqual({ body: '18972631', verifier: '7' })
-    })
-  })
-
-  describe('error cases', () => {
-    test('throws error for invalid RUT', () => {
-      expect(() => decompose('123')).toThrow()
-      expect(() => decompose('invalid')).toThrow()
-      expect(() => decompose('')).toThrow()
-    })
-
-    test('throws error for too short RUT', () => {
-      expect(() => decompose('1234567')).toThrow()
-      expect(() => decompose('1.234.567')).toThrow()
-    })
-
-    test('throws error for too long RUT', () => {
-      expect(() => decompose('12345678901')).toThrow()
-    })
-  })
-
-  describe('with throwOnError: false (safe mode)', () => {
-    test('returns null for invalid RUT instead of throwing', () => {
-      expect(decompose('123', { throwOnError: false })).toBeNull()
-      expect(decompose('', { throwOnError: false })).toBeNull()
-      expect(decompose('invalid', { throwOnError: false })).toBeNull()
-    })
-
-    test('returns null for non-string inputs', () => {
-      expect(decompose(123456789 as any, { throwOnError: false })).toBeNull()
-      expect(decompose(null as any, { throwOnError: false })).toBeNull()
-    })
-
-    test('returns decomposed RUT when valid', () => {
+    test('returns the decomposed shape for valid input', () => {
       expect(decompose('18.972.631-7', { throwOnError: false })).toEqual({ body: '18972631', verifier: '7' })
-      expect(decompose('9.068.826-K', { throwOnError: false })).toEqual({ body: '9068826', verifier: 'K' })
     })
   })
 
-  describe('edge cases', () => {
-    test('preserves verifier 0', () => {
-      expect(decompose('18.264.159-0')).toEqual({ body: '18264159', verifier: '0' })
+  describe('error mode (default)', () => {
+    test('throws a generic error with no PII echoed', () => {
+      expect(() => decompose('not-a-rut')).toThrow('Invalid RUT input')
+      expect(() => decompose('not-a-rut')).not.toThrow(/not-a-rut/)
     })
 
-    test('handles minimum valid RUT', () => {
-      expect(decompose('1.000.000-2')).toEqual({ body: '1000000', verifier: '2' })
+    test.each([[''], ['123'], ['12345678901']])('throws for invalid input: %p', (input) => {
+      expect(() => decompose(input)).toThrow('Invalid RUT input')
     })
+  })
 
-    test('handles maximum valid RUT', () => {
-      expect(decompose('99.999.999-6')).toEqual({ body: '99999999', verifier: '6' })
-    })
+  describe('consistency with getBody / getVerifier / clean (property)', () => {
+    // If `decompose` ever drifts from its composition, this catches it.
+    test.each(['18.972.631-7', '9.068.826-K', '14.625.621-k', '  18.972.631-7  ', '009.068.826-K'])(
+      'decompose(%p).body === getBody(%p) and verifier === getVerifier(%p)',
+      (rut) => {
+        const d = decompose(rut)
+        expect(d.body).toBe(getBody(rut))
+        expect(d.verifier).toBe(getVerifier(rut))
+        expect(d.body + d.verifier).toBe(clean(rut))
+      },
+    )
   })
 })

--- a/tests/differential.test.ts
+++ b/tests/differential.test.ts
@@ -363,4 +363,82 @@ const CORPUS = Number(process.env.DIFF_CORPUS ?? 1_000_000)
     expect(validateV4('12.345678-5')).toBe(false)
     expect(legacyValidate('12.345.678-5')).toBe(validateV4('12.345.678-5'))
   })
+
+  /**
+   * Mini-corpus run on every CI invocation (no env flag required). This is a
+   * 1 000-case version of the full differential — small enough to be cheap
+   * (< 100 ms locally) but large enough to make sure that the only divergence
+   * shapes between v3.4.0 and v4.0.0 are the ones documented in the CHANGELOG.
+   *
+   * The full 1 M-case report-writing run is still gated behind
+   * `RUN_DIFFERENTIAL=1`; this block does NOT write any report.
+   */
+  test('mini-corpus (1k cases) only diverges on documented shapes', () => {
+    const allowedRegressions = new Set(['noncanonical-grouping', 'len-65-over-cap'])
+    const allowedNewAccepts = new Set(['surrounding-space'])
+
+    const regressionShapes = new Set<string>()
+    const newAcceptShapes = new Set<string>()
+    const rng = mulberry32(0x1234_5678)
+    const ri = (min: number, max: number) => min + Math.floor(rng() * (max - min + 1))
+
+    for (let i = 0; i < 250; i++) {
+      // Stratum A: known-valid bodies in many shapes.
+      const len = rng() < 0.5 ? 7 : 8
+      let body = String(ri(0, 9) || 1)
+      do {
+        body = String(ri(0, 9) || 1)
+        for (let j = 1; j < len; j++) body += String(ri(0, 9))
+      } while (/^(.)\1*$/.test(body))
+      const dv = dvOf(body)
+
+      const head = body.length === 8 ? body.slice(0, 2) : body.slice(0, 1)
+      const rest = body.length === 8 ? body.slice(2) : body.slice(1)
+      const dotted = `${head}.${rest.slice(0, 3)}.${rest.slice(3)}`
+
+      const rows: Array<{ input: string; shape: string }> = [
+        { input: `${body}${dv}`, shape: 'compact' },
+        { input: `${body}-${dv}`, shape: 'compact+hyphen' },
+        { input: `${dotted}-${dv}`, shape: 'canonical-dotted' },
+        { input: `  ${dotted}-${dv}  `, shape: 'surrounding-space' },
+        { input: `${body.slice(0, 2)}.${body.slice(2)}-${dv}`, shape: 'noncanonical-grouping' },
+      ]
+      for (const { input, shape } of rows) {
+        const o = legacyValidate(input)
+        const n = validateV4(input)
+        if (o && !n) regressionShapes.add(shape)
+        else if (!o && n) newAcceptShapes.add(shape)
+      }
+    }
+
+    // 65-char-padded valid RUT: v3 accepts, v4 rejects (cap).
+    {
+      const overCap = '0'.repeat(56) + '123456785'
+      const o = legacyValidate(overCap)
+      const n = validateV4(overCap)
+      if (o && !n) regressionShapes.add('len-65-over-cap')
+    }
+
+    const unexpectedRegressions = [...regressionShapes].filter((s) => !allowedRegressions.has(s))
+    const unexpectedNewAccepts = [...newAcceptShapes].filter((s) => !allowedNewAccepts.has(s))
+    expect(unexpectedRegressions).toEqual([])
+    expect(unexpectedNewAccepts).toEqual([])
+  })
+
+  test('ReDoS on 100k-char adversarial input is below 50 ms on v4', () => {
+    // Defense-in-depth — also covered in validate.test.ts. The v3 frozen regex
+    // is *deliberately* never fed this input here; we only time the hardened
+    // v4 validator.
+    const adversarial = '0'.repeat(100_000) + 'x'
+    const start = performance.now()
+    const result = validateV4(adversarial)
+    const elapsed = performance.now() - start
+    expect(result).toBe(false)
+    expect(elapsed).toBeLessThan(50)
+  })
+
+  test('strict uppercase-K bypass remains fixed', () => {
+    expect(legacyValidate('8.888.888-K', { strict: true })).toBe(true) // documented v3 bug
+    expect(validateV4('8.888.888-K', { strict: true })).toBe(false) // v4 fix
+  })
 })

--- a/tests/dist.smoke.test.ts
+++ b/tests/dist.smoke.test.ts
@@ -1,0 +1,112 @@
+import { execFileSync } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { join } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+/**
+ * Dual-package smoke test for the built `dist/` artefacts.
+ *
+ * Why this exists: the project ships both ESM and CJS entries with their own
+ * type definitions. The dual-build wiring is fragile — package.json `exports`,
+ * the per-target `tsc --module` flags, the minifier step, and the
+ * `dist/cjs/package.json` `{"type":"commonjs"}` marker all have to stay in
+ * sync. A regression in any of those would not be caught by the source-level
+ * jest run, but it WILL be caught here as soon as the smoke fails to import.
+ *
+ * The test is auto-skipped if `dist/` has not been built (e.g. a fresh clone
+ * before `npm run prepare`), so it never blocks contributors who only edit
+ * source.
+ *
+ * Implementation note: the ESM smoke spawns a fresh Node subprocess to load
+ * the .esm.min.js file under the real ESM loader. Jest's ts-jest host runs
+ * tests in CJS mode, so a direct `import()` from inside a test would route
+ * through Jest's module transformer and silently re-evaluate the file as
+ * CJS — defeating the point of the smoke. The subprocess approach measures
+ * what an actual consumer would see.
+ */
+const distRoot = join(__dirname, '..', 'dist')
+const cjsEntry = join(distRoot, 'cjs', 'index.min.js')
+const esmEntry = join(distRoot, 'esm', 'index.min.js')
+const cjsPkgJson = join(distRoot, 'cjs', 'package.json')
+
+const EXPECTED_NAMES = [
+  'validate',
+  'clean',
+  'format',
+  'calculateVerifier',
+  'getBody',
+  'getVerifier',
+  'decompose',
+  'generate',
+  'isRutLike',
+  'getInvalidRutError',
+] as const
+
+const distExists = existsSync(cjsEntry) && existsSync(esmEntry)
+const guarded = distExists ? describe : describe.skip
+
+guarded('dist smoke (dual ESM + CJS package)', () => {
+  test('CJS entry loads via require() and exposes the full public API', () => {
+    // Use createRequire so this works under ts-jest's CJS host regardless of
+    // the root package.json `"type": "module"` setting.
+    const req = createRequire(__filename)
+    const cjs = req(cjsEntry) as Record<string, unknown>
+    for (const name of EXPECTED_NAMES) {
+      expect(typeof cjs[name]).toBe('function')
+    }
+    expect((cjs.validate as (s: string) => boolean)('12.345.678-5')).toBe(true)
+    expect((cjs.format as (s: string) => string)('123456785')).toBe('12.345.678-5')
+    expect((cjs.getInvalidRutError as () => string)()).toBe('Invalid RUT input')
+  })
+
+  test('CJS subpackage is marked { "type": "commonjs" } (afterbuild step)', () => {
+    const req = createRequire(__filename)
+    const pkg = req(cjsPkgJson) as { type?: string }
+    expect(pkg.type).toBe('commonjs')
+  })
+
+  test('ESM entry loads under a real ESM loader and exposes the full public API', () => {
+    // The fresh-process invariant: pass the ESM URL on stdin instead of as an
+    // -e flag, so quoting around the URL is never an issue.
+    const esmUrl = pathToFileURL(esmEntry).href
+    const loaderScript = `
+      import(${JSON.stringify(esmUrl)}).then(
+        (mod) => {
+          const names = Object.keys(mod).sort();
+          const validateOk = typeof mod.validate === 'function' && mod.validate('12.345.678-5') === true;
+          const calcOk = typeof mod.calculateVerifier === 'function' && mod.calculateVerifier('12345678') === '5';
+          process.stdout.write(JSON.stringify({ names, validateOk, calcOk }));
+        },
+        (err) => {
+          process.stderr.write(String(err));
+          process.exit(1);
+        }
+      );
+    `
+    const stdout = execFileSync(process.execPath, ['--input-type=module', '-e', loaderScript], { encoding: 'utf8' })
+    const result = JSON.parse(stdout) as { names: string[]; validateOk: boolean; calcOk: boolean }
+    for (const name of EXPECTED_NAMES) {
+      expect(result.names).toContain(name)
+    }
+    expect(result.validateOk).toBe(true)
+    expect(result.calcOk).toBe(true)
+  })
+
+  test('CJS and ESM expose the same set of public names', () => {
+    const req = createRequire(__filename)
+    const cjs = req(cjsEntry) as Record<string, unknown>
+    const cjsNames = EXPECTED_NAMES.filter((n) => typeof cjs[n] === 'function').sort()
+
+    const esmUrl = pathToFileURL(esmEntry).href
+    const loaderScript = `
+      import(${JSON.stringify(esmUrl)}).then(
+        (mod) => process.stdout.write(JSON.stringify(Object.keys(mod).sort())),
+        (err) => { process.stderr.write(String(err)); process.exit(1); }
+      );
+    `
+    const stdout = execFileSync(process.execPath, ['--input-type=module', '-e', loaderScript], { encoding: 'utf8' })
+    const esmNames = (JSON.parse(stdout) as string[]).filter((n) => (EXPECTED_NAMES as readonly string[]).includes(n))
+    expect(esmNames.sort()).toEqual(cjsNames)
+  })
+})

--- a/tests/format.test.ts
+++ b/tests/format.test.ts
@@ -1,87 +1,177 @@
 import { format } from '../src'
 
 describe('format', () => {
-  describe('with throwOnError: false (safe mode)', () => {
-    test('Returns null for invalid RUT instead of throwing', () => {
-      expect(format('123', { throwOnError: false })).toBeNull()
+  describe('standard formatting (non-incremental)', () => {
+    test.each([
+      ['189726317', { dots: true }, '18.972.631-7'],
+      ['189726317', { dots: false }, '18972631-7'],
+      ['123456785', { dots: true }, '12.345.678-5'],
+      ['123456785', { dots: false }, '12345678-5'],
+      ['14625621k', undefined, '14.625.621-K'],
+      ['09068826K', undefined, '9.068.826-K'],
+      ['0012345674', undefined, '1.234.567-4'],
+      ['009068826K', undefined, '9.068.826-K'],
+      ['14.625.621-k', undefined, '14.625.621-K'],
+      ['12#345#678#5', undefined, '12.345.678-5'],
+      [' 123 456 785 ', undefined, '12.345.678-5'],
+      ['12-345-678-5', undefined, '12.345.678-5'],
+      ['18.972.631-7', undefined, '18.972.631-7'], // idempotent on canonical input
+      ['9.068.826-K', undefined, '9.068.826-K'],
+      ['10000130', undefined, '1.000.013-0'], // verifier 0 boundary
+    ])('format(%p, %p) === %p', (rut, options, expected) => {
+      expect(format(rut, options)).toBe(expected)
     })
 
-    test('Returns formatted RUT when valid', () => {
-      expect(format('189726317', { throwOnError: false })).toBe('18.972.631-7')
+    test('format is idempotent on its own output', () => {
+      for (const input of ['18.972.631-7', '14.625.621-K', '9.068.826-K']) {
+        const once = format(input)
+        expect(format(once)).toBe(once)
+      }
     })
 
-    test('Supports other options combined with throwOnError', () => {
-      expect(format('189726317', { dots: false, throwOnError: false })).toBe('18972631-7')
-    })
-
-    test('Returns null for RUTs that are too short', () => {
-      expect(format('1234567', { throwOnError: false })).toBeNull()
-    })
-
-    test('Returns null for RUTs that are too long', () => {
-      expect(format('12345678901', { throwOnError: false })).toBeNull()
-    })
-
-    test('Returns null for RUTs with an incorrect verifier', () => {
-      expect(format('123456789', { throwOnError: false })).toBeNull()
-    })
-
-    test('Returns null for non-string inputs', () => {
-      expect(format(123456785 as any, { throwOnError: false })).toBeNull()
-      expect(format(null as any, { throwOnError: false })).toBeNull()
+    test('returns empty string for empty input (does not throw)', () => {
+      expect(format('')).toBe('')
     })
   })
 
-  describe('incremental mode (progressive formatting)', () => {
-    test('Formats partial RUTs progressively (without hyphen until 8+ chars)', () => {
-      expect(format('1', { incremental: true })).toBe('1')
-      expect(format('12', { incremental: true })).toBe('12')
-      expect(format('123', { incremental: true })).toBe('123')
-      expect(format('1234', { incremental: true })).toBe('1.234')
-      expect(format('12345', { incremental: true })).toBe('12.345')
-      expect(format('123456', { incremental: true })).toBe('123.456')
-      expect(format('1234567', { incremental: true })).toBe('1.234.567')
+  describe('verifier validation (v4 breaking change #1)', () => {
+    // v3 silently "repaired" an incorrect verifier; v4 rejects.
+    test('throws on numeric wrong verifier (default mode)', () => {
+      expect(() => format('123456789')).toThrow('Invalid RUT input')
     })
 
-    test('Adds hyphen when RUT is complete (8+ chars)', () => {
-      // With 8 chars: 7 body + 1 verifier
-      expect(format('12345678', { incremental: true })).toBe('1.234.567-8')
-      // With 9 chars: 8 body + 1 verifier
-      expect(format('123456789', { incremental: true })).toBe('12.345.678-9')
+    test('throws on K-verifier mismatch (default mode)', () => {
+      // body 1234567 has DV 4, not K — v3 used to "repair" this; v4 rejects.
+      expect(() => format('1234567K')).toThrow('Invalid RUT input')
+      // body 12345678 has DV 5, not K.
+      expect(() => format('12345678K')).toThrow('Invalid RUT input')
     })
 
-    test('Formats complete RUTs without dots', () => {
-      expect(format('1234', { incremental: true, dots: false })).toBe('1234')
-      expect(format('12345678', { incremental: true, dots: false })).toBe('1234567-8')
-      expect(format('123456789', { incremental: true, dots: false })).toBe('12345678-9')
+    test('returns null in safe mode for any wrong verifier', () => {
+      expect(format('123456789', { throwOnError: false })).toBeNull()
+      expect(format('1234567K', { throwOnError: false })).toBeNull()
+      expect(format('12345678K', { throwOnError: false })).toBeNull()
     })
 
-    test('Handles RUT with K verifier', () => {
-      expect(format('1234567K', { incremental: true })).toBe('1.234.567-K')
-      expect(format('1234567k', { incremental: true })).toBe('1.234.567-K')
-      expect(format('12345678K', { incremental: true })).toBe('12.345.678-K')
+    test('does not echo the input in the error message (PII protection)', () => {
+      expect(() => format('123456789')).not.toThrow(/123/)
+    })
+  })
+
+  describe('safe mode (throwOnError: false)', () => {
+    test.each([
+      ['', '', 'empty string short-circuits to ""'],
+      ['189726317', '18.972.631-7', 'valid RUT formats normally'],
+    ])('format(%p, { throwOnError: false }) === %p (%s)', (input, expected, _label) => {
+      expect(format(input, { throwOnError: false })).toBe(expected)
     })
 
-    test('Returns empty string for empty input', () => {
-      expect(format('', { incremental: true })).toBe('')
+    test('supports throwOnError combined with other options', () => {
+      expect(format('189726317', { dots: false, throwOnError: false })).toBe('18972631-7')
     })
 
-    test('Cleans input while formatting incrementally', () => {
-      expect(format('12.345', { incremental: true })).toBe('12.345')
-      expect(format('12-345-678', { incremental: true })).toBe('1.234.567-8')
+    test.each([
+      ['123', 'too short'],
+      ['1234567', '7 chars'],
+      ['12345678901', '11 chars'],
+      ['123456789', 'wrong verifier'],
+      ['K234567-8', 'K at the start'],
+      ['1234K678-9', 'K in the middle'],
+    ])('returns null for invalid input: %p (%s)', (input, _label) => {
+      expect(format(input, { throwOnError: false })).toBeNull()
     })
 
-    test('Removes leading zeros in incremental mode', () => {
-      expect(format('00001234', { incremental: true })).toBe('1.234')
-      expect(format('00012345678', { incremental: true })).toBe('1.234.567-8')
+    test.each([
+      [123456785, 'number'],
+      [null, 'null'],
+      [undefined, 'undefined'],
+      [{}, 'object'],
+      [Symbol('rut'), 'symbol'],
+    ])('returns null for non-string input: %p (%s)', (value, _label) => {
+      expect(format(value as unknown as string, { throwOnError: false })).toBeNull()
+    })
+  })
+
+  describe('error mode (default)', () => {
+    test.each([['1234567'], ['123'], ['12345678901'], ['K234567-8'], ['1234K678-9']])(
+      'throws for invalid input: %p',
+      (input) => {
+        expect(() => format(input)).toThrow('Invalid RUT input')
+      },
+    )
+  })
+
+  describe('security — MAX_RUT_INPUT_LENGTH (64) cap', () => {
+    test('accepts input padded to exactly 64 chars in non-incremental mode', () => {
+      const padded = '0'.repeat(55) + '123456785' // length 64, valid DV
+      expect(padded.length).toBe(64)
+      expect(format(padded)).toBe('12.345.678-5')
     })
 
-    test('Caps very long inputs to the maximum RUT length', () => {
+    test('rejects input at 65 chars (over the cap)', () => {
+      const overCap = '0'.repeat(56) + '123456785'
+      expect(overCap.length).toBe(65)
+      expect(format(overCap, { throwOnError: false })).toBeNull()
+      expect(() => format(overCap)).toThrow('Invalid RUT input')
+    })
+  })
+
+  describe('incremental mode — progressive formatting', () => {
+    test.each([
+      ['1', '1'],
+      ['12', '12'],
+      ['123', '123'],
+      ['1234', '1.234'],
+      ['12345', '12.345'],
+      ['123456', '123.456'],
+      ['1234567', '1.234.567'],
+      // hyphen appears at 8+ chars (complete)
+      ['12345678', '1.234.567-8'],
+      ['123456789', '12.345.678-9'],
+    ])('format(%p, { incremental: true }) === %p (length sweep 1..9)', (input, expected) => {
+      expect(format(input, { incremental: true })).toBe(expected)
+    })
+
+    test.each([
+      ['1234', '1234'],
+      ['12345678', '1234567-8'],
+      ['123456789', '12345678-9'],
+    ])('with dots:false, format(%p, incremental) === %p', (input, expected) => {
+      expect(format(input, { incremental: true, dots: false })).toBe(expected)
+    })
+
+    test.each([
+      ['1234567K', '1.234.567-K'],
+      ['1234567k', '1.234.567-K'],
+      ['12345678K', '12.345.678-K'],
+    ])('K verifier (case-insensitive) in incremental: %p → %p', (input, expected) => {
+      expect(format(input, { incremental: true })).toBe(expected)
+    })
+
+    test.each([
+      ['', ''],
+      ['   ', ''], // whitespace-only normalizes to empty
+      ['00000000', ''], // all zeros strip to empty
+      ['00001234', '1.234'],
+      ['00012345678', '1.234.567-8'],
+    ])('strips leading zeros / empty edge cases: %p → %p', (input, expected) => {
+      expect(format(input, { incremental: true })).toBe(expected)
+    })
+
+    test.each([
+      ['12.345', '12.345'],
+      ['12-345-678', '1.234.567-8'],
+      ['12#34#56#78', '1.234.567-8'],
+    ])('cleans input while formatting incrementally: %p → %p', (input, expected) => {
+      expect(format(input, { incremental: true })).toBe(expected)
+    })
+
+    test('caps very long inputs to the maximum RUT length (v4 breaking change #7)', () => {
       expect(format('12345678901234', { incremental: true })).toBe('12.345.678-9')
     })
 
-    test('Caps to 9 significant chars and drops a trailing K beyond the cap', () => {
-      // A trailing K is preserved only while the value still fits in 9 chars...
+    test('caps to 9 significant chars and drops a trailing K beyond the cap', () => {
+      // A trailing K is preserved only while the value still fits in 9 chars.
       expect(format('123456785K', { incremental: true })).toBe('12.345.678-5')
       expect(format('12.345.678-K', { incremental: true })).toBe('12.345.678-K')
       // ...but once normalization yields >9 significant chars, the cap to
@@ -92,91 +182,20 @@ describe('format', () => {
       expect(format('12345678901234K', { incremental: true })).toBe('12.345.678-9')
     })
 
-    test('Handles special characters in incremental mode', () => {
-      expect(format('12#34#56#78', { incremental: true })).toBe('1.234.567-8')
-    })
-  })
-
-  describe('standard formatting', () => {
-    test('should correctly format RUTs with or without dots', () => {
-      expect(format('189726317')).toBe('18.972.631-7')
-      expect(format('189726317', { dots: false })).toBe('18972631-7')
+    test('silently drops a K that is not the trailing character', () => {
+      // Locks in observed behavior so a refactor cannot silently regress it.
+      // These inputs would never come from a normal typing flow, but a paste
+      // could produce them — the renderer keeps only digits + trailing K.
+      expect(format('K12345678', { incremental: true })).toBe('1.234.567-8')
+      expect(format('1234K5678', { incremental: true })).toBe('1.234.567-8')
+      expect(format('KK345678', { incremental: true })).toBe('345.678')
     })
 
-    test('Correctly formats with dots and hyphen', () => {
-      expect(format('123456785')).toBe('12.345.678-5')
-    })
-
-    test('Correctly formats without dots', () => {
-      expect(format('123456785', { dots: false })).toBe('12345678-5')
-    })
-
-    test('Returns empty string if input is empty', () => {
-      expect(format('')).toBe('')
-    })
-
-    test('Correctly handles RUTs with K as verification digit', () => {
-      expect(format('14625621k')).toBe('14.625.621-K')
-      expect(format('09068826K')).toBe('9.068.826-K')
-    })
-
-    test('Correctly formats RUTs with leading zeros', () => {
-      expect(format('0012345674')).toBe('1.234.567-4')
-      expect(format('009068826K')).toBe('9.068.826-K')
-    })
-
-    test('Correctly handles RUTs with non-numeric characters', () => {
-      expect(format('14.625.621-k')).toBe('14.625.621-K')
-      expect(format('12#345#678#5')).toBe('12.345.678-5')
-    })
-
-    test('Correctly handles RUTs with white spaces', () => {
-      expect(format(' 123 456 785 ')).toBe('12.345.678-5')
-    })
-
-    test('Throws for RUTs with an incorrect verifier', () => {
-      expect(() => format('123456789')).toThrow()
-    })
-  })
-
-  describe('edge cases', () => {
-    test('Formats 8-character RUTs (7 body + 1 verifier)', () => {
-      expect(format('09068826K')).toBe('9.068.826-K')
-      expect(format('12345674')).toBe('1.234.567-4')
-    })
-
-    test('Formats 9-character RUTs (8 body + 1 verifier)', () => {
-      expect(format('189726317')).toBe('18.972.631-7')
-      expect(format('123456785')).toBe('12.345.678-5')
-    })
-
-    test('Formats with verifier 0', () => {
-      expect(format('10000130')).toBe('1.000.013-0')
-    })
-
-    test('Already formatted RUTs remain unchanged', () => {
-      expect(format('18.972.631-7')).toBe('18.972.631-7')
-      expect(format('9.068.826-K')).toBe('9.068.826-K')
-    })
-
-    test('Handles RUT with only hyphens as separators', () => {
-      expect(format('12-345-678-5')).toBe('12.345.678-5')
-    })
-  })
-
-  describe('error cases', () => {
-    test('Throws error for too short RUT', () => {
-      expect(() => format('1234567')).toThrow()
-      expect(() => format('123')).toThrow()
-    })
-
-    test('Throws error for too long RUT', () => {
-      expect(() => format('12345678901')).toThrow()
-    })
-
-    test('Throws error for RUT with K not at the end', () => {
-      expect(() => format('K234567-8')).toThrow()
-      expect(() => format('1234K678-9')).toThrow()
+    test('incremental mode never throws regardless of throwOnError', () => {
+      // Documented contract: throwOnError is ignored in incremental mode.
+      expect(() => format('@@@@', { incremental: true, throwOnError: true })).not.toThrow()
+      expect(() => format('00000000', { incremental: true, throwOnError: true })).not.toThrow()
+      expect(() => format('K@K@K@', { incremental: true, throwOnError: true })).not.toThrow()
     })
   })
 })

--- a/tests/generate.test.ts
+++ b/tests/generate.test.ts
@@ -1,122 +1,108 @@
 import { generate, validate, format, decompose } from '../src'
 
-export const createArray = (length: number) => new Array(length).fill(0)
+const createArray = (length: number) => new Array(length).fill(0)
 
-describe('generate function', () => {
-  describe('basic generation', () => {
-    test('generates a valid RUT', () => {
-      const rut = generate()
-      expect(validate(rut)).toBeTruthy()
-    })
-
-    test('generates a formatted RUT with dots and hyphen', () => {
+describe('generate', () => {
+  describe('shape and structure', () => {
+    test('emits a single canonical formatted RUT', () => {
       const rut = generate()
       expect(rut).toMatch(/^\d{1,2}\.\d{3}\.\d{3}-[\dK]$/)
-    })
-
-    test('generates RUT with correct structure', () => {
-      const rut = generate()
-      const decomposed = decompose(rut)
-      expect(decomposed.body).toHaveLength(8) // Body is always 8 digits
-      expect(decomposed.verifier).toHaveLength(1) // Verifier is always 1 char
-    })
-  })
-
-  describe('validation of generated RUTs', () => {
-    test('should generate 999 valid RUTs', () => {
-      const results = createArray(999).map(() => {
-        const generatedRUT = generate()
-        const isValid = validate(generatedRUT)
-        return { generated: generatedRUT, isValid }
-      })
-
-      results.forEach((result) => {
-        expect(result.isValid).toBeTruthy()
-      })
-    })
-
-    test('all generated RUTs pass strict validation', () => {
-      const ruts = createArray(50).map(() => generate())
-      ruts.forEach((rut) => {
-        expect(validate(rut, { strict: true })).toBeTruthy()
-      })
-    })
-  })
-
-  describe('verifier digit variety', () => {
-    test('generated RUTs can have different verifiers', () => {
-      const ruts = createArray(100).map(() => generate())
-      const verifiers = ruts.map((rut) => decompose(rut).verifier)
-      const uniqueVerifiers = new Set(verifiers)
-
-      // Should generate RUTs with at least 2 different verifiers in 100 attempts
-      expect(uniqueVerifiers.size).toBeGreaterThan(1)
-    })
-
-    test('generated RUTs can have K as verifier', () => {
-      // Generate many RUTs and check if at least one has K
-      const ruts = createArray(200).map(() => generate())
-      const hasK = ruts.some((rut) => decompose(rut).verifier === 'K')
-
-      // Probability of getting at least one K in 200 RUTs is very high
-      // (roughly 1/11 chance per RUT)
-      expect(hasK).toBeTruthy()
-    })
-  })
-
-  describe('format consistency', () => {
-    test('generated RUTs are consistently formatted', () => {
-      const ruts = createArray(10).map(() => generate())
-      ruts.forEach((rut) => {
-        // Check it's properly formatted
-        expect(rut).toMatch(/^\d{1,2}\.\d{3}\.\d{3}-[\dK]$/)
-
-        // Check it can be reformatted to same value
-        const reformatted = format(rut)
-        expect(reformatted).toBe(rut)
-      })
-    })
-  })
-
-  describe('randomness', () => {
-    test('generates different RUTs', () => {
-      const rut1 = generate()
-      const rut2 = generate()
-      const rut3 = generate()
-
-      // Very unlikely to generate same RUT twice in a row
-      expect(rut1).not.toBe(rut2)
-      expect(rut2).not.toBe(rut3)
-    })
-
-    test('generates RUTs in realistic range', () => {
-      const ruts = createArray(20).map(() => generate())
-      ruts.forEach((rut) => {
-        const { body } = decompose(rut)
-        const bodyNum = parseInt(body, 10)
-
-        // Generated RUTs should be in the range 10000000-99999999
-        expect(bodyNum).toBeGreaterThanOrEqual(10000000)
-        expect(bodyNum).toBeLessThanOrEqual(99999999)
-      })
-    })
-  })
-
-  describe('generated RUT properties', () => {
-    test('generated RUT has valid length', () => {
-      const rut = generate()
-      // Format: XX.XXX.XXX-Y (13 chars) or X.XXX.XXX-Y (12 chars)
       expect(rut.length).toBeGreaterThanOrEqual(12)
       expect(rut.length).toBeLessThanOrEqual(13)
     })
 
-    test('generated RUT body is always 8 digits', () => {
-      const ruts = createArray(50).map(() => generate())
-      ruts.forEach((rut) => {
-        const { body } = decompose(rut)
+    test('body is always 8 digits (per MIN_GENERATED_BODY..MAX_GENERATED_BODY)', () => {
+      for (const rut of createArray(50).map(() => generate())) {
+        const { body, verifier } = decompose(rut)
         expect(body).toHaveLength(8)
-        expect(/^\d{8}$/.test(body)).toBeTruthy()
+        expect(verifier).toHaveLength(1)
+        expect(/^\d{8}$/.test(body)).toBe(true)
+        const n = parseInt(body, 10)
+        expect(n).toBeGreaterThanOrEqual(10_000_000)
+        expect(n).toBeLessThanOrEqual(99_999_999)
+      }
+    })
+  })
+
+  describe('validity (Monte Carlo)', () => {
+    test('999 generated RUTs all pass validate (regression for v4-fixed range bug)', () => {
+      for (const rut of createArray(999).map(() => generate())) {
+        expect(validate(rut)).toBe(true)
+      }
+    })
+
+    test('100 generated RUTs all pass strict validate (regression for v4-fixed suspicious body)', () => {
+      // v3 could emit all-same-digit bodies (e.g. 11.111.111-1) which strict
+      // mode rejects. v4 retries until a non-suspicious body is drawn.
+      for (const rut of createArray(100).map(() => generate())) {
+        expect(validate(rut, { strict: true })).toBe(true)
+        const { body } = decompose(rut)
+        expect(/^(\d)\1*$/.test(body)).toBe(false)
+      }
+    })
+
+    test('round-trips through format() unchanged (consistent canonical form)', () => {
+      for (const rut of createArray(20).map(() => generate())) {
+        expect(format(rut)).toBe(rut)
+      }
+    })
+  })
+
+  describe('randomness', () => {
+    test('does not emit the same RUT twice consecutively', () => {
+      const [a, b, c] = [generate(), generate(), generate()]
+      expect(a).not.toBe(b)
+      expect(b).not.toBe(c)
+    })
+
+    test('verifier distribution covers more than one digit value', () => {
+      // P(all 200 share the same verifier) ≈ 11 × (1/11)^200 ≈ 10^-208 → effectively zero.
+      const verifiers = new Set(createArray(200).map(() => decompose(generate()).verifier))
+      expect(verifiers.size).toBeGreaterThan(1)
+    })
+
+    test('verifier K appears within a reasonable sample (≈1/11 per draw)', () => {
+      // P(no K in 200) ≈ (10/11)^200 ≈ 5×10^-9. Stable in practice.
+      const hasK = createArray(200)
+        .map(() => generate())
+        .some((rut) => decompose(rut).verifier === 'K')
+      expect(hasK).toBe(true)
+    })
+  })
+
+  describe('CSPRNG fallback branch (Math.random when Web Crypto unavailable)', () => {
+    // The v4 generator uses Web Crypto with unbiased rejection sampling when
+    // `globalThis.crypto.getRandomValues` is available, and falls back to
+    // `Math.random()` on older runtimes. Under Node test runs the crypto path
+    // is always taken; this block shadows `globalThis.crypto` so the fallback
+    // branch is exercised explicitly.
+    let originalCryptoDescriptor: PropertyDescriptor | undefined
+
+    beforeAll(() => {
+      originalCryptoDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'crypto')
+      // Use `undefined` so the `cryptoSource?.getRandomValues` short-circuit
+      // selects the Math.random branch deterministically.
+      Object.defineProperty(globalThis, 'crypto', {
+        value: undefined,
+        configurable: true,
+        writable: true,
       })
+    })
+
+    afterAll(() => {
+      if (originalCryptoDescriptor) {
+        Object.defineProperty(globalThis, 'crypto', originalCryptoDescriptor)
+      } else {
+        // Restore by deletion if the property did not exist before.
+        delete (globalThis as unknown as { crypto?: unknown }).crypto
+      }
+    })
+
+    test('falls back to Math.random and still produces valid RUTs', () => {
+      expect(globalThis.crypto).toBeUndefined()
+      for (const rut of createArray(100).map(() => generate())) {
+        expect(validate(rut, { strict: true })).toBe(true)
+      }
     })
   })
 })

--- a/tests/getBody.test.ts
+++ b/tests/getBody.test.ts
@@ -1,106 +1,84 @@
-import { getBody } from '../src'
+import { calculateVerifier, clean, getBody, getVerifier } from '../src'
 
-describe('getBody function', () => {
-  describe('basic functionality', () => {
-    test('should return the body of a RUT', () => {
-      expect(getBody('18.972.631-7')).toBe('18972631')
-    })
-
-    test('extracts body from RUT with K verifier', () => {
-      expect(getBody('9.068.826-K')).toBe('9068826')
-      expect(getBody('14.625.621-k')).toBe('14625621')
-    })
-
-    test('extracts body from RUT without dots', () => {
-      expect(getBody('18972631-7')).toBe('18972631')
-      expect(getBody('9068826K')).toBe('9068826')
-    })
-
-    test('extracts body from RUT without hyphen', () => {
-      expect(getBody('189726317')).toBe('18972631')
-      expect(getBody('12345678K')).toBe('12345678')
-    })
-  })
-
-  describe('various formats', () => {
-    test('handles RUT with leading zeros', () => {
-      expect(getBody('009.068.826-K')).toBe('9068826')
-      expect(getBody('0018972631-7')).toBe('18972631')
-    })
-
-    test('handles RUT with extra characters', () => {
-      expect(getBody('  18.972.631-7  ')).toBe('18972631')
-      expect(getBody('(18.972.631-7)')).toBe('18972631')
-    })
-
-    test('handles RUT with all special characters removed', () => {
-      expect(getBody('18#972#631-7')).toBe('18972631')
+/**
+ * `getBody` is `clean(rut)?.slice(0, -1)`. The matrix of parsing edge cases
+ * lives in `clean.test.ts`. This file covers what is unique to `getBody`:
+ *
+ * 1. it returns the body (everything except the last char of clean output)
+ * 2. it never returns a K in the result (K is always the verifier)
+ * 3. safe-mode null contract
+ * 4. generic error message
+ * 5. consistency with clean() and getVerifier()
+ */
+describe('getBody', () => {
+  describe('basic extraction', () => {
+    test.each([
+      ['18.972.631-7', '18972631'],
+      ['9.068.826-K', '9068826'],
+      ['14.625.621-k', '14625621'],
+      ['189726317', '18972631'], // compact
+      ['9068826K', '9068826'], // compact
+      ['009.068.826-K', '9068826'], // leading zeros
+      ['  18.972.631-7  ', '18972631'], // surrounding whitespace
+      ['(18.972.631-7)', '18972631'], // permissive char strip
+      ['18#972#631-7', '18972631'], // special chars stripped
+      ['18.264.159-0', '18264159'], // verifier 0
+      ['1.000.000-2', '1000000'], // minimum-length body
+    ])('getBody(%p) === %p', (input, expected) => {
+      expect(getBody(input)).toBe(expected)
     })
   })
 
-  describe('length variations', () => {
-    test('extracts body from 8-digit RUT', () => {
-      expect(getBody('9.068.826-K')).toBe('9068826')
-      expect(getBody('1.000.000-2')).toBe('1000000')
-    })
-
-    test('extracts body from 9-digit RUT', () => {
-      expect(getBody('18.972.631-7')).toBe('18972631')
-      expect(getBody('99.999.999-6')).toBe('99999999')
-    })
+  test('the returned body never contains K (K is always the verifier)', () => {
+    for (const rut of ['9.068.826-K', '14.625.621-k', '9068826K', '14625621K']) {
+      const body = getBody(rut)
+      expect(body).not.toContain('K')
+      expect(body).not.toContain('k')
+    }
   })
 
-  describe('error cases', () => {
-    test('throws error for invalid RUT', () => {
-      expect(() => getBody('123')).toThrow()
-      expect(() => getBody('invalid')).toThrow()
-      expect(() => getBody('')).toThrow()
+  describe('safe mode (throwOnError: false)', () => {
+    test.each([
+      ['', 'empty'],
+      ['123', 'too short'],
+      ['invalid', 'non-numeric'],
+    ])('returns null for invalid input: %p (%s)', (input, _label) => {
+      expect(getBody(input, { throwOnError: false })).toBeNull()
     })
 
-    test('throws error for too short RUT', () => {
-      expect(() => getBody('1234567')).toThrow()
+    test.each([[123456789], [null], [undefined], [{}]])('returns null for non-string input: %p', (value) => {
+      expect(getBody(value as unknown as string, { throwOnError: false })).toBeNull()
     })
 
-    test('throws error for too long RUT', () => {
-      expect(() => getBody('12345678901')).toThrow()
-    })
-  })
-
-  describe('with throwOnError: false (safe mode)', () => {
-    test('returns null for invalid RUT instead of throwing', () => {
-      expect(getBody('123', { throwOnError: false })).toBeNull()
-      expect(getBody('', { throwOnError: false })).toBeNull()
-      expect(getBody('invalid', { throwOnError: false })).toBeNull()
-    })
-
-    test('returns null for non-string inputs', () => {
-      expect(getBody(123456789 as any, { throwOnError: false })).toBeNull()
-      expect(getBody(null as any, { throwOnError: false })).toBeNull()
-    })
-
-    test('returns body when valid', () => {
+    test('returns the body for valid input', () => {
       expect(getBody('18.972.631-7', { throwOnError: false })).toBe('18972631')
       expect(getBody('9.068.826-K', { throwOnError: false })).toBe('9068826')
     })
   })
 
-  describe('edge cases', () => {
-    test('extracts body correctly when verifier is 0', () => {
-      expect(getBody('18.264.159-0')).toBe('18264159')
+  describe('error mode (default)', () => {
+    test('throws a generic error with no PII echoed', () => {
+      expect(() => getBody('secret-rut')).toThrow('Invalid RUT input')
+      expect(() => getBody('secret-rut')).not.toThrow(/secret/)
     })
 
-    test('handles minimum valid RUT', () => {
-      expect(getBody('1.000.000-2')).toBe('1000000')
+    test.each([['1234567'], ['12345678901']])('throws for out-of-range length: %p', (input) => {
+      expect(() => getBody(input)).toThrow('Invalid RUT input')
     })
+  })
 
-    test('handles maximum valid RUT', () => {
-      expect(getBody('99.999.999-6')).toBe('99999999')
-    })
+  describe('consistency with clean and getVerifier (property)', () => {
+    test.each(['18.972.631-7', '9.068.826-K', '14.625.621-k', '009.068.826-K', ' 18972631-7 '])(
+      'getBody(%p) + getVerifier(%p) === clean(%p)',
+      (rut) => {
+        expect(getBody(rut) + getVerifier(rut)).toBe(clean(rut))
+      },
+    )
 
-    test('body never contains K', () => {
-      const body = getBody('9.068.826-K')
-      expect(body).not.toContain('K')
-      expect(body).not.toContain('k')
+    test('calculateVerifier(getBody(x)) reproduces the canonical verifier of x for valid x', () => {
+      for (const rut of ['18.972.631-7', '9.068.826-K', '12.345.678-5', '99.999.999-9']) {
+        expect(calculateVerifier(getBody(rut))).toBe(getVerifier(rut))
+      }
     })
   })
 })

--- a/tests/getInvalidRutError.test.ts
+++ b/tests/getInvalidRutError.test.ts
@@ -1,0 +1,37 @@
+import { getInvalidRutError } from '../src'
+
+/**
+ * `getInvalidRutError` is part of the v4 public API. Its v3 signature
+ * `(rut: string) => string` echoed the raw input into the message — which
+ * leaked Chilean ID values into logs, traces and alerts. v4 changed it to
+ * `(_rut?: unknown) => string` and made it always return the constant
+ * `'Invalid RUT input'`.
+ *
+ * These tests anchor that contract so a future refactor cannot silently
+ * re-introduce PII into the error message.
+ */
+describe('getInvalidRutError', () => {
+  test('returns the canonical generic message', () => {
+    expect(getInvalidRutError()).toBe('Invalid RUT input')
+  })
+
+  test.each([
+    ['12.345.678-5', 'a valid-shaped RUT'],
+    ['secret-rut-99.999.999-9', 'a RUT-shaped substring'],
+    [{ pii: 'leak-me' } as unknown, 'an object payload'],
+    [123456789 as unknown, 'a numeric payload'],
+    [null as unknown, 'null'],
+    [undefined as unknown, 'undefined'],
+    [Symbol('rut') as unknown, 'a symbol'],
+  ])('never echoes the input back (%p — %s)', (input) => {
+    const message = getInvalidRutError(input)
+    expect(message).toBe('Invalid RUT input')
+    // Defensive negative assertion: nothing that could resemble the input
+    // ever appears in the message, regardless of how it stringifies.
+    expect(message).not.toMatch(/12345678|99999999|secret|leak/)
+  })
+
+  test('return value is referentially stable as a constant string', () => {
+    expect(getInvalidRutError('a')).toBe(getInvalidRutError('b'))
+  })
+})

--- a/tests/getVerifier.test.ts
+++ b/tests/getVerifier.test.ts
@@ -1,131 +1,112 @@
-import { getVerifier } from '../src'
+import { calculateVerifier, clean, getBody, getVerifier } from '../src'
 
-describe('getVerifier function', () => {
-  describe('basic functionality', () => {
-    test('should return the verifier of a RUT', () => {
-      expect(getVerifier('23.579.222-2')).toBe('2')
-      expect(getVerifier('18.972.631-7')).toBe('7')
-    })
-
-    test('extracts K verifier (uppercase)', () => {
-      expect(getVerifier('9.068.826-K')).toBe('K')
-      expect(getVerifier('14.625.621-K')).toBe('K')
-    })
-
-    test('extracts k verifier and converts to uppercase', () => {
-      expect(getVerifier('9.068.826-k')).toBe('K')
-      expect(getVerifier('14.625.621-k')).toBe('K')
-    })
-
-    test('extracts verifier from RUT without dots', () => {
-      expect(getVerifier('18972631-7')).toBe('7')
-      expect(getVerifier('9068826K')).toBe('K')
-    })
-
-    test('extracts verifier from RUT without hyphen', () => {
-      expect(getVerifier('189726317')).toBe('7')
-      expect(getVerifier('12345678K')).toBe('K')
-    })
-  })
-
-  describe('various formats', () => {
-    test('handles RUT with leading zeros', () => {
-      expect(getVerifier('009.068.826-K')).toBe('K')
-      expect(getVerifier('0018972631-7')).toBe('7')
-    })
-
-    test('handles RUT with extra characters', () => {
-      expect(getVerifier('  18.972.631-7  ')).toBe('7')
-      expect(getVerifier('(18.972.631-7)')).toBe('7')
-    })
-
-    test('handles RUT with special characters', () => {
-      expect(getVerifier('18#972#631-7')).toBe('7')
+/**
+ * `getVerifier` is `clean(rut)?.slice(-1)`. Parsing edge cases are covered
+ * by `clean.test.ts`. This file covers what is unique to `getVerifier`:
+ *
+ * 1. it returns a single character of type VerifierDigit ('0'..'9' | 'K')
+ * 2. lowercase k is normalized to uppercase K
+ * 3. the full 0..9, K image is reachable via real RUTs
+ * 4. safe-mode null contract
+ * 5. generic error message
+ */
+describe('getVerifier', () => {
+  describe('basic extraction', () => {
+    test.each([
+      ['23.579.222-2', '2'],
+      ['18.972.631-7', '7'],
+      ['9.068.826-K', 'K'],
+      ['14.625.621-K', 'K'],
+      ['18972631-7', '7'],
+      ['189726317', '7'],
+      ['009.068.826-K', 'K'],
+      ['  18.972.631-7  ', '7'],
+      ['(18.972.631-7)', '7'],
+      ['18#972#631-7', '7'],
+    ])('getVerifier(%p) === %p', (input, expected) => {
+      expect(getVerifier(input)).toBe(expected)
     })
   })
 
-  describe('verifier digit variations', () => {
-    test('extracts verifier digit 0', () => {
-      expect(getVerifier('18.264.159-0')).toBe('0')
-    })
-
-    test('extracts all numeric verifiers (0-9)', () => {
-      expect(getVerifier('18.264.159-0')).toBe('0')
-      expect(getVerifier('11.111.111-1')).toBe('1')
-      expect(getVerifier('23.579.222-2')).toBe('2')
-      expect(getVerifier('18.972.631-7')).toBe('7')
-      expect(getVerifier('18.264.958-9')).toBe('9')
-    })
-
-    test('extracts K verifier', () => {
-      expect(getVerifier('9.068.826-K')).toBe('K')
+  describe('case normalization', () => {
+    test.each([
+      ['9.068.826-k', 'K'],
+      ['14.625.621-k', 'K'],
+      ['9068826k', 'K'],
+      ['9.068.826-K', 'K'],
+    ])('lowercase k is uppercased: %p → %p', (input, expected) => {
+      expect(getVerifier(input)).toBe(expected)
     })
   })
 
-  describe('length variations', () => {
-    test('extracts verifier from 8-digit RUT', () => {
-      expect(getVerifier('9.068.826-K')).toBe('K')
-      expect(getVerifier('1.000.000-2')).toBe('2')
-    })
-
-    test('extracts verifier from 9-digit RUT', () => {
-      expect(getVerifier('18.972.631-7')).toBe('7')
-      expect(getVerifier('99.999.999-6')).toBe('6')
-    })
-  })
-
-  describe('error cases', () => {
-    test('throws error for invalid RUT', () => {
-      expect(() => getVerifier('123')).toThrow()
-      expect(() => getVerifier('invalid')).toThrow()
-      expect(() => getVerifier('')).toThrow()
-    })
-
-    test('throws error for too short RUT', () => {
-      expect(() => getVerifier('1234567')).toThrow()
-    })
-
-    test('throws error for too long RUT', () => {
-      expect(() => getVerifier('12345678901')).toThrow()
+  describe('full image (every possible verifier output)', () => {
+    // For each of the 11 possible outputs, take the smallest 8-digit body
+    // whose Modulo-11 verifier is that output, and verify that getVerifier
+    // returns it on the compact body+DV string.
+    const cases: Array<[string, string]> = [
+      ['10000004', '0'],
+      ['10000009', '1'],
+      ['10000003', '2'],
+      ['10000008', '3'],
+      ['10000002', '4'],
+      ['10000007', '5'],
+      ['10000001', '6'],
+      ['10000006', '7'],
+      ['10000000', '8'],
+      ['10000005', '9'],
+      ['10000013', 'K'],
+    ]
+    test.each(cases)('extracts verifier %2$p from compact RUT (body %1$s)', (body, dv) => {
+      expect(getVerifier(body + dv)).toBe(dv)
     })
   })
 
-  describe('with throwOnError: false (safe mode)', () => {
-    test('returns null for invalid RUT instead of throwing', () => {
-      expect(getVerifier('123', { throwOnError: false })).toBeNull()
-      expect(getVerifier('', { throwOnError: false })).toBeNull()
-      expect(getVerifier('invalid', { throwOnError: false })).toBeNull()
+  test('return value is always exactly one character', () => {
+    for (const rut of ['18.972.631-7', '9.068.826-K', '14.625.621-k', '99.999.999-9']) {
+      expect(getVerifier(rut)).toHaveLength(1)
+    }
+  })
+
+  describe('safe mode (throwOnError: false)', () => {
+    test.each([
+      ['', 'empty'],
+      ['123', 'too short'],
+      ['invalid', 'non-numeric'],
+    ])('returns null for invalid input: %p (%s)', (input, _label) => {
+      expect(getVerifier(input, { throwOnError: false })).toBeNull()
     })
 
-    test('returns null for non-string inputs', () => {
-      expect(getVerifier(123456789 as any, { throwOnError: false })).toBeNull()
-      expect(getVerifier(null as any, { throwOnError: false })).toBeNull()
+    test.each([[123456789], [null], [undefined], [{}]])('returns null for non-string input: %p', (value) => {
+      expect(getVerifier(value as unknown as string, { throwOnError: false })).toBeNull()
     })
 
-    test('returns verifier when valid', () => {
+    test('returns the verifier for valid input', () => {
       expect(getVerifier('23.579.222-2', { throwOnError: false })).toBe('2')
       expect(getVerifier('9.068.826-K', { throwOnError: false })).toBe('K')
     })
   })
 
-  describe('edge cases', () => {
-    test('verifier is always a single character', () => {
-      expect(getVerifier('18.972.631-7')).toHaveLength(1)
-      expect(getVerifier('9.068.826-K')).toHaveLength(1)
+  describe('error mode (default)', () => {
+    test('throws a generic error with no PII echoed', () => {
+      expect(() => getVerifier('secret-rut')).toThrow('Invalid RUT input')
+      expect(() => getVerifier('secret-rut')).not.toThrow(/secret/)
     })
 
-    test('handles minimum valid RUT', () => {
-      expect(getVerifier('1.000.000-2')).toBe('2')
+    test.each([['1234567'], ['12345678901']])('throws for out-of-range length: %p', (input) => {
+      expect(() => getVerifier(input)).toThrow('Invalid RUT input')
     })
+  })
 
-    test('handles maximum valid RUT', () => {
-      expect(getVerifier('99.999.999-6')).toBe('6')
-    })
-
-    test('verifier is always uppercase for K', () => {
-      expect(getVerifier('9.068.826-k')).toBe('K')
-      expect(getVerifier('9068826k')).toBe('K')
-      expect(getVerifier('9.068.826-K')).toBe('K')
-    })
+  describe('consistency with clean and getBody (property)', () => {
+    test.each(['18.972.631-7', '9.068.826-K', '14.625.621-k', '009.068.826-K'])(
+      'clean(%p).endsWith(getVerifier(%p))',
+      (rut) => {
+        const c = clean(rut)
+        const v = getVerifier(rut)
+        expect(c.endsWith(v)).toBe(true)
+        // And the digit value must match what calculateVerifier computes for the body.
+        expect(calculateVerifier(getBody(rut))).toBe(v)
+      },
+    )
   })
 })

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -1,0 +1,111 @@
+import { expectTypeOf } from 'expect-type'
+
+import {
+  calculateVerifier,
+  clean,
+  decompose,
+  format,
+  generate,
+  getBody,
+  getInvalidRutError,
+  getVerifier,
+  isRutLike,
+  validate,
+} from '../src'
+import type { DecomposedRut, FormatOptions, SafeOptions, ValidateOptions, VerifierDigit } from '../src'
+
+/**
+ * Type-level regression tests for the v4 overload contract.
+ *
+ * The library overloads every safe-mode helper so that:
+ *
+ *   fn(input)                              → non-nullable result (may throw)
+ *   fn(input, { throwOnError: false })     → nullable result (returns null)
+ *   fn(input, { throwOnError: true  })     → non-nullable result (may throw)
+ *   fn(input, options?: SafeOptions)       → nullable (the catch-all fallback)
+ *
+ * Without these tests, a future refactor of the overload signatures could
+ * silently widen a return type to `T | null` (or narrow it) without any
+ * runtime failure, breaking downstream type ergonomics.
+ *
+ * The assertions are wrapped in functions that ts-jest type-checks at compile
+ * time but never invokes — so the same `expectTypeOf(fn(arg))` form works
+ * regardless of whether `arg` would be a valid RUT at runtime.
+ */
+
+const _typecheck = () => {
+  // ── clean ──────────────────────────────────────────────────────────────
+  expectTypeOf(clean('x')).toEqualTypeOf<string>()
+  expectTypeOf(clean('x', { throwOnError: false })).toEqualTypeOf<string | null>()
+  expectTypeOf(clean('x', { throwOnError: true })).toEqualTypeOf<string>()
+  // The catch-all (options?: SafeOptions) signature is necessarily nullable.
+  const safeOpts: SafeOptions | undefined = undefined
+  expectTypeOf(clean('x', safeOpts)).toEqualTypeOf<string | null>()
+
+  // ── getBody ────────────────────────────────────────────────────────────
+  expectTypeOf(getBody('x')).toEqualTypeOf<string>()
+  expectTypeOf(getBody('x', { throwOnError: false })).toEqualTypeOf<string | null>()
+  expectTypeOf(getBody('x', { throwOnError: true })).toEqualTypeOf<string>()
+
+  // ── getVerifier (returns the narrow VerifierDigit union) ───────────────
+  expectTypeOf(getVerifier('x')).toEqualTypeOf<VerifierDigit>()
+  expectTypeOf(getVerifier('x', { throwOnError: false })).toEqualTypeOf<VerifierDigit | null>()
+  expectTypeOf(getVerifier('x', { throwOnError: true })).toEqualTypeOf<VerifierDigit>()
+
+  // ── decompose (returns the DecomposedRut shape) ────────────────────────
+  expectTypeOf(decompose('x')).toEqualTypeOf<DecomposedRut>()
+  expectTypeOf(decompose('x', { throwOnError: false })).toEqualTypeOf<DecomposedRut | null>()
+  expectTypeOf(decompose('x', { throwOnError: true })).toEqualTypeOf<DecomposedRut>()
+
+  // ── calculateVerifier ──────────────────────────────────────────────────
+  expectTypeOf(calculateVerifier('x')).toEqualTypeOf<VerifierDigit>()
+  expectTypeOf(calculateVerifier('x', { throwOnError: false })).toEqualTypeOf<VerifierDigit | null>()
+  expectTypeOf(calculateVerifier('x', { throwOnError: true })).toEqualTypeOf<VerifierDigit>()
+
+  // ── format (incremental mode still returns string) ─────────────────────
+  expectTypeOf(format('x')).toEqualTypeOf<string>()
+  expectTypeOf(format('x', { dots: false })).toEqualTypeOf<string>()
+  expectTypeOf(format('x', { incremental: true })).toEqualTypeOf<string>()
+  expectTypeOf(format('x', { incremental: true, dots: false })).toEqualTypeOf<string>()
+  expectTypeOf(format('x', { throwOnError: false })).toEqualTypeOf<string | null>()
+  expectTypeOf(format('x', { throwOnError: true })).toEqualTypeOf<string>()
+  expectTypeOf(format('x', { incremental: true, throwOnError: false })).toEqualTypeOf<string | null>()
+
+  // ── validate / isRutLike (predicates over unknown) ─────────────────────
+  expectTypeOf(validate('x')).toEqualTypeOf<boolean>()
+  expectTypeOf(validate('x', { strict: true })).toEqualTypeOf<boolean>()
+  expectTypeOf(validate(123 as unknown)).toEqualTypeOf<boolean>()
+  expectTypeOf(isRutLike('x')).toEqualTypeOf<boolean>()
+  expectTypeOf(isRutLike(null as unknown)).toEqualTypeOf<boolean>()
+
+  // ── generate ───────────────────────────────────────────────────────────
+  expectTypeOf(generate()).toEqualTypeOf<string>()
+
+  // ── getInvalidRutError (accepts unknown, returns the constant string) ──
+  expectTypeOf(getInvalidRutError()).toEqualTypeOf<string>()
+  expectTypeOf(getInvalidRutError('x')).toEqualTypeOf<string>()
+  expectTypeOf(getInvalidRutError({ pii: 'x' } as unknown)).toEqualTypeOf<string>()
+
+  // ── exported option types stay object-shaped ───────────────────────────
+  expectTypeOf<FormatOptions>().toMatchObjectType<{
+    incremental?: boolean
+    dots?: boolean
+    throwOnError?: boolean
+  }>()
+  expectTypeOf<ValidateOptions>().toMatchObjectType<{ strict?: boolean }>()
+  expectTypeOf<SafeOptions>().toMatchObjectType<{ throwOnError?: boolean }>()
+  expectTypeOf<DecomposedRut>().toMatchObjectType<{ body: string; verifier: string }>()
+
+  // ── VerifierDigit is the closed union ──────────────────────────────────
+  expectTypeOf<VerifierDigit>().toEqualTypeOf<'0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | 'K'>()
+}
+
+describe('type-level overloads', () => {
+  // Single runtime test whose only job is to keep this file as a valid Jest
+  // suite. The real assertions are above and are checked at compile time by
+  // ts-jest. If any overload signature regresses, the file fails to compile
+  // — which surfaces as a Jest "suite failed to run" error.
+  test('overload assertions compile (see _typecheck above)', () => {
+    expect(typeof _typecheck).toBe('function')
+  })
+})

--- a/tests/validate.test.ts
+++ b/tests/validate.test.ts
@@ -2,164 +2,241 @@ import { validate, isRutLike } from '../src'
 
 describe('validate', () => {
   describe('type safety (accepts unknown)', () => {
-    test('Returns false for non-string inputs', () => {
-      expect(validate(123456789 as unknown)).toBeFalsy()
-      expect(validate(null as unknown)).toBeFalsy()
-      expect(validate(undefined as unknown)).toBeFalsy()
-      expect(validate({} as unknown)).toBeFalsy()
-      expect(validate([] as unknown)).toBeFalsy()
-      expect(validate(true as unknown)).toBeFalsy()
-      expect(validate(false as unknown)).toBeFalsy()
+    test.each([
+      [123456789, 'number'],
+      [null, 'null'],
+      [undefined, 'undefined'],
+      [{}, 'object'],
+      [[], 'array'],
+      [true, 'boolean true'],
+      [false, 'boolean false'],
+      [NaN, 'NaN'],
+      [Infinity, 'Infinity'],
+      [-Infinity, '-Infinity'],
+      [-0, '-0'],
+      [Symbol('rut'), 'symbol'],
+    ])('returns false for non-string input: %p (%s)', (value, _label) => {
+      expect(validate(value as unknown)).toBe(false)
     })
   })
 
-  describe('valid RUTs', () => {
-    test('should correctly validate RUTs', () => {
-      expect(validate('13.611.947-8')).toBeTruthy()
-      expect(validate('18.972.631-7')).toBeTruthy()
-      expect(validate('09.068.826-K')).toBeTruthy() // 09068826 = 8 digits
+  describe('valid RUTs — the three accepted shapes', () => {
+    // Same RUT (12.345.678-5) across the three documented canonical shapes.
+    // Replaces the older "different formats" / "should correctly validate" /
+    // "validates 8-digit" / "validates 9-digit" duplicate blocks.
+    test.each([
+      ['12.345.678-5', 'canonical dotted'],
+      ['12345678-5', 'compact with hyphen'],
+      ['123456785', 'compact'],
+      ['1.234.567-4', 'canonical dotted (7-digit body)'],
+      ['1234567-4', 'compact-with-hyphen (7-digit body)'],
+      ['12345674', 'compact (7-digit body)'],
+    ])('accepts valid RUT in shape: %s (%s)', (rut) => {
+      expect(validate(rut)).toBe(true)
     })
 
-    test('validates RUTs with different formats', () => {
-      // With dots and hyphen
-      expect(validate('12.345.678-5')).toBeTruthy()
-      // Without dots
-      expect(validate('12345678-5')).toBeTruthy()
-      // Without dots or hyphen
-      expect(validate('123456785')).toBeTruthy()
+    test.each([
+      ['14.625.621-K', 'uppercase K'],
+      ['14.625.621-k', 'lowercase k'],
+      ['14625621K', 'compact uppercase'],
+      ['14625621k', 'compact lowercase'],
+    ])('accepts K verifier (case-insensitive): %s', (rut) => {
+      expect(validate(rut)).toBe(true)
     })
 
-    test('validates RUTs with K verifier (uppercase and lowercase)', () => {
-      expect(validate('14.625.621-K')).toBeTruthy()
-      expect(validate('14.625.621-k')).toBeTruthy()
-      expect(validate('14625621K')).toBeTruthy()
-      expect(validate('14625621k')).toBeTruthy()
+    test.each([
+      ['009.068.826-K', '7-digit body + 2 leading zeros'],
+      ['0009068826K', 'compact + 3 leading zeros'],
+      ['018.972.631-7', '8-digit body + 1 leading zero'],
+      ['00012345674', 'compact + 3 leading zeros (7-digit body, DV 4)'],
+    ])('accepts leading zeros: %s', (rut) => {
+      expect(validate(rut)).toBe(true)
     })
 
-    test('validates RUTs with leading zeros', () => {
-      expect(validate('009.068.826-K')).toBeTruthy() // 9 digits with leading zeros
-      expect(validate('0009068826K')).toBeTruthy()
-      expect(validate('018.972.631-7')).toBeTruthy()
+    test('accepts verifier digit 0 (covers the 11 - sum%11 === 11 branch of Modulo-11)', () => {
+      expect(validate('18.264.950-3')).toBe(true)
+      // A RUT whose verifier is literally '0' — i.e. checkDigit === 11.
+      expect(validate('10.000.004-0')).toBe(true)
     })
 
-    test('validates 8-digit RUTs (after removing leading zeros)', () => {
-      expect(validate('09.068.826-K')).toBeTruthy()
-      expect(validate('09068826K')).toBeTruthy()
-    })
-
-    test('validates 9-digit RUTs', () => {
-      expect(validate('18.972.631-7')).toBeTruthy()
-      expect(validate('189726317')).toBeTruthy()
+    test('accepts the documented minimum and maximum body', () => {
+      expect(validate('10.000.000-8')).toBe(true)
+      expect(validate('010.000.002-4')).toBe(true) // normalizes to 10000024
+      expect(validate('99.999.999-9')).toBe(true)
     })
   })
 
   describe('invalid RUTs', () => {
-    test('should reject invalid RUTs', () => {
-      expect(validate('18.972.631-8')).toBeFalsy() // Wrong verifier
-      expect(validate('invalid')).toBeFalsy()
-      expect(validate('1.1.1-1')).toBeFalsy()
+    test.each([
+      ['18.972.631-8', 'wrong verifier on 8-digit body'],
+      ['23.478.522-K', 'wrong verifier (K) on 8-digit body'],
+      ['12.345.678-0', 'wrong verifier (0 instead of 5)'],
+    ])('rejects wrong verifier: %s (%s)', (rut) => {
+      expect(validate(rut)).toBe(false)
     })
 
-    test('invalidates RUT with incorrect verification digit', () => {
-      expect(validate('23.478.522-K')).toBeFalsy()
-      expect(validate('12.345.678-0')).toBeFalsy() // Should be 5
+    test.each([
+      ['invalid', 'pure non-numeric'],
+      ['abcdefghi', 'alphabetic only'],
+      ['1.1.1-1', 'too few digits with dots'],
+      ['', 'empty'],
+      ['12#34%56&789K', 'special chars'],
+      ['12,345,678-5', 'comma grouping (v4: rejected)'],
+      ['12.345678-5', 'non-canonical grouping (v4 breaking change #2)'],
+      ['12345.678-5', 'non-canonical grouping (v4 breaking change #2)'],
+      ['1.2.3.4.5.6.7.8-5', 'every-digit-dotted (v4 breaking change #2)'],
+      ['12 345 678 5', 'internal whitespace (only the three shapes are accepted)'],
+      ['K2345678-5', 'K not at end (leading)'],
+      ['1234K678-5', 'K not at end (middle)'],
+      ['1234567K-K', 'multiple K'],
+      ['KK345678-5', 'multiple K (leading)'],
+    ])('rejects invalid input: %p (%s)', (rut) => {
+      expect(validate(rut)).toBe(false)
     })
 
-    test('invalidates RUT in incorrect format', () => {
-      expect(validate('abcdefghi')).toBeFalsy()
-      expect(validate('12,345,678-5')).toBeFalsy() // Commas not supported
-      expect(validate('12.345678-5')).toBeFalsy()
-      expect(validate('12345.678-5')).toBeFalsy()
+    test.each([
+      ['123', 'too short'],
+      ['1234567', 'just under min length after leading-zero strip'],
+      ['12345678901', 'too long but under 64-char cap'],
+    ])('rejects out-of-range length: %p (%s)', (rut) => {
+      expect(validate(rut)).toBe(false)
+    })
+  })
+
+  describe('security — MAX_RUT_INPUT_LENGTH (64) cap', () => {
+    // The cap is a security bound (defense against ReDoS-style abuse), not a
+    // format rule. These boundary tests anchor the exact 64/65 split so a
+    // future refactor cannot widen the cap silently.
+    test('accepts a valid RUT padded with zeros to exactly 64 chars', () => {
+      const padded = '0'.repeat(55) + '123456785' // length 64, normalizes to 123456785
+      expect(padded.length).toBe(64)
+      expect(validate(padded)).toBe(true)
     })
 
-    test('invalidates empty RUT', () => {
-      expect(validate('')).toBeFalsy()
+    test('rejects input at MAX_RUT_INPUT_LENGTH + 1 (65 chars)', () => {
+      const overCap = '0'.repeat(56) + '123456785' // length 65
+      expect(overCap.length).toBe(65)
+      expect(validate(overCap)).toBe(false)
     })
 
-    test('invalidates RUT with special characters', () => {
-      expect(validate('12#34%56&789K')).toBeFalsy()
+    test('rejects far-over-cap adversarial input', () => {
+      expect(validate(`${'0'.repeat(128)}x`)).toBe(false)
+      expect(validate('1'.repeat(20000))).toBe(false)
     })
 
-    test('invalidates RUT with incorrect length', () => {
-      expect(validate('123')).toBeFalsy()
-      expect(validate('1234567')).toBeFalsy()
-      expect(validate('12345678901')).toBeFalsy()
-      expect(validate(`${'0'.repeat(128)}x`)).toBeFalsy()
+    test('is ReDoS-safe on a 100k-char adversarial input (catastrophic-backtracking regression)', () => {
+      // Promoted from the gated differential suite. The v3 regex
+      // `/^0*(\d{1,3}(\.?\d{3})*)-?([\dkK])$/` exhibited catastrophic
+      // backtracking on this input (~353 ms and growing super-linearly).
+      // The v4 input is length-capped *before* any regex runs, so this must
+      // resolve in well under 50 ms on any reasonable CI hardware.
+      const adversarial = '0'.repeat(100_000) + 'x'
+      const start = performance.now()
+      const result = validate(adversarial)
+      const elapsed = performance.now() - start
+      expect(result).toBe(false)
+      expect(elapsed).toBeLessThan(50)
+    })
+  })
+
+  describe('whitespace handling (v4 breaking change #3 — trim)', () => {
+    test.each([
+      ['  12.345.678-5  ', 'leading + trailing spaces'],
+      ['\t12.345.678-5\n', 'tab + newline'],
+      ['  123456785  ', 'compact with surrounding spaces'],
+      ['\n14.625.621-K\t', 'K verifier with surrounding whitespace'],
+    ])('accepts otherwise-valid input with surrounding whitespace: %p (%s)', (rut) => {
+      expect(validate(rut)).toBe(true)
     })
 
-    test('invalidates RUT with K not at the end', () => {
-      expect(validate('K2345678-5')).toBeFalsy()
-      expect(validate('1234K678-5')).toBeFalsy()
+    test('whitespace-only input is rejected', () => {
+      expect(validate('   ')).toBe(false)
+      expect(validate('\t\n')).toBe(false)
     })
 
-    test('invalidates RUT with multiple K', () => {
-      expect(validate('1234567K-K')).toBeFalsy()
-      expect(validate('KK345678-5')).toBeFalsy()
+    test('surrounding whitespace does not turn invalid into valid', () => {
+      expect(validate('  invalid  ')).toBe(false)
+      expect(validate('  12.345.678-0  ')).toBe(false) // wrong verifier
+    })
+  })
+
+  describe('Unicode / non-ASCII inputs (anti-spoofing)', () => {
+    // The invalidRutChars regex is ASCII-only ([^0-9kK]). These tests anchor
+    // that policy so look-alike characters cannot bypass validation.
+    test.each([
+      ['१२३४५६७८-५', 'Devanagari digits'],
+      ['１２３４５６７８-５', 'fullwidth digits'],
+      ['‮12345678-5', 'leading RTL override mark'],
+      ['12345678-5​', 'trailing zero-width space'],
+      ['12.345.678-К', 'Cyrillic К (U+041A) instead of ASCII K'],
+    ])('rejects non-ASCII look-alike input: %p (%s)', (rut) => {
+      expect(validate(rut)).toBe(false)
     })
   })
 
   describe('strict mode', () => {
-    test('should reject suspicious RUTs when strict mode is enabled', () => {
-      expect(validate('11.111.111-1', { strict: true })).toBeFalsy()
-      expect(validate('22.222.222-2', { strict: true })).toBeFalsy()
-      expect(validate('33.333.333-3', { strict: true })).toBeFalsy()
-      expect(validate('8.888.888-K', { strict: true })).toBeFalsy()
-      expect(validate('8888888K', { strict: true })).toBeFalsy()
+    test.each([
+      ['11.111.111-1', 'all 1s'],
+      ['22.222.222-2', 'all 2s'],
+      ['33.333.333-3', 'all 3s'],
+      ['8.888.888-K', 'all 8s with K (v4 fix for strict uppercase-K bypass)'],
+      ['8888888K', 'all 8s with K — compact (regression for strict uppercase-K bypass)'],
+    ])('rejects suspicious RUT in strict mode: %s', (rut) => {
+      expect(validate(rut, { strict: true })).toBe(false)
     })
 
-    test('validates suspicious RUT if strict is false or not provided', () => {
-      expect(validate('11111111-1')).toBeTruthy()
-      expect(validate('11111111-1', { strict: false })).toBeTruthy()
-      expect(validate('11111111-1', {})).toBeTruthy()
-    })
+    test.each([[undefined], [{ strict: false } as const], [{} as const]])(
+      'accepts suspicious RUT when strict is off / not provided (options=%p)',
+      (opts) => {
+        expect(validate('11111111-1', opts)).toBe(true)
+      },
+    )
 
-    test('strict mode does not affect normal valid RUTs', () => {
-      expect(validate('12.345.678-5', { strict: true })).toBeTruthy()
-      expect(validate('18.972.631-7', { strict: true })).toBeTruthy()
-    })
-  })
-
-  describe('edge cases', () => {
-    test('validates RUT with verifier digit 0', () => {
-      expect(validate('18.264.950-3')).toBeTruthy()
-    })
-
-    test('validates minimum valid RUT (with leading zeros removed)', () => {
-      expect(validate('010.000.002-4')).toBeTruthy() // Becomes 10000024 (8 digits)
-      expect(validate('10.000.000-8')).toBeTruthy()
-    })
-
-    test('validates maximum valid RUT', () => {
-      expect(validate('99.999.999-9')).toBeTruthy()
+    test('strict mode does not reject otherwise-valid RUTs', () => {
+      expect(validate('12.345.678-5', { strict: true })).toBe(true)
+      expect(validate('18.972.631-7', { strict: true })).toBe(true)
     })
   })
 })
 
 describe('isRutLike', () => {
-  test('Returns true for valid RUT formats', () => {
-    expect(isRutLike('12.345.678-9')).toBeTruthy()
-    expect(isRutLike('12345678-9')).toBeTruthy()
-    expect(isRutLike('123456789')).toBeTruthy()
-    expect(isRutLike('1.234.567-K')).toBeTruthy()
+  test.each([
+    ['12.345.678-9', 'canonical dotted'],
+    ['12345678-9', 'compact with hyphen'],
+    ['123456789', 'compact'],
+    ['1.234.567-K', 'canonical dotted 7-digit body, K verifier'],
+    ['009.068.826-K', 'with leading zeros'],
+    ['00012345678', 'compact with leading zeros'],
+    ['  12.345.678-5  ', 'with surrounding whitespace (v4 trim)'],
+    ['12.345.678-k', 'lowercase k'],
+  ])('returns true for shape-valid input: %p (%s)', (rut) => {
+    expect(isRutLike(rut)).toBe(true)
   })
 
-  test('Returns false for invalid formats', () => {
-    expect(isRutLike('abcdefghi')).toBeFalsy()
-    expect(isRutLike('')).toBeFalsy()
-    expect(isRutLike('12.34.56-7')).toBeFalsy()
-    expect(isRutLike('12.345678-5')).toBeFalsy()
-    expect(isRutLike('12345.678-5')).toBeFalsy()
-    expect(isRutLike('1'.repeat(128))).toBeFalsy()
+  test.each([
+    ['abcdefghi', 'pure alphabetic'],
+    ['', 'empty'],
+    ['12.34.56-7', 'wrong dot grouping'],
+    ['12.345678-5', 'non-canonical grouping'],
+    ['12345.678-5', 'non-canonical grouping'],
+    ['1'.repeat(128), 'over 64-char cap'],
+    ['12 345 678 5', 'internal whitespace'],
+    ['K2345678-5', 'K not at end'],
+  ])('returns false for shape-invalid input: %p (%s)', (rut) => {
+    expect(isRutLike(rut)).toBe(false)
   })
 
-  test('Returns true for RUTs with leading zeros', () => {
-    expect(isRutLike('009.068.826-K')).toBeTruthy()
-    expect(isRutLike('00012345678')).toBeTruthy()
+  test.each([
+    [123456789, 'number'],
+    [null, 'null'],
+    [undefined, 'undefined'],
+    [{}, 'object'],
+  ])('returns false for non-string input: %p (%s)', (value, _label) => {
+    expect(isRutLike(value as unknown)).toBe(false)
   })
 
-  test('Returns false for non-string inputs', () => {
-    expect(isRutLike(123456789 as any)).toBeFalsy()
-    expect(isRutLike(null as any)).toBeFalsy()
-    expect(isRutLike(undefined as any)).toBeFalsy()
+  test('respects the 64-char cap at the exact boundary', () => {
+    expect(isRutLike('0'.repeat(55) + '123456785')).toBe(true) // length 64
+    expect(isRutLike('0'.repeat(56) + '123456785')).toBe(false) // length 65
   })
 })


### PR DESCRIPTION
## Summary

Comprehensive audit and expansion of the test suite, plus synchronization of every documented test count to the real total Jest reports.

The previous documentation claimed **182 test cases**. The suite now contains **394** — this PR makes the docs tell the truth and bundles in the maintainer-validated changes that were already in the working tree.

## Test changes

- **Rewrote and expanded all eight per-function suites** — `validate`, `format`, `clean`, `getVerifier`, `calculateVerifier`, `decompose`, `getBody`, `generate` — with broader edge-case, safe-mode (`throwOnError: false`), and strict-mode coverage.
- **Expanded `differential.test.ts`** — cross-checks against a reference implementation; opt-in via `RUN_DIFFERENTIAL=1`.
- **New `getInvalidRutError.test.ts`** — covers the error helper.
- **New `dist.smoke.test.ts`** — exercises the built bundle so packaging regressions are caught.
- **New `types.test.ts`** — compile-time type assertions; adds the `expect-type` devDependency (`package.json` / `package-lock.json`).
- Jest now reports **394 total test cases, 100% pass rate** (12 suites).

Per-file breakdown:

| Suite | Tests |
|---|---|
| validate | 93 |
| format | 69 |
| clean | 62 |
| calculateVerifier | 47 |
| getVerifier | 41 |
| getBody | 29 |
| decompose | 21 |
| generate | 9 |
| getInvalidRutError | 9 |
| differential (opt-in) | 9 |
| dist.smoke | 4 |
| types | 1 |
| **Total** | **394** |

## Documentation changes

- `docs/src/content/testing.mdx` — updated the intro line, the coverage stats (now **12 test suites / 394 test cases**), and the per-file test tree to the real counts.
- `llms.txt` and `docs/public/llms.txt` — testing-guide entry updated from `182 tests` to `394 tests`.

## Maintainer-validated changes folded in

These were already prepared and validated by the maintainer; included here so they ship together:

- `llms.txt` / `docs/public/llms.txt` — corrected gzipped bundle size from `~1.1KB` to `~1.4KB`.
- Docs landing page (`docs/src/app/page.jsx`) — restyle and the `394` test-cases stat.

## Verification

- `npm test` → 394 total, all green (5 differential tests skipped by default; run with `RUN_DIFFERENTIAL=1` to include them).
- `npm run lint` → clean.

