### PR TITLE
chore(release): 5.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ metadata**: they are accurate but summarized, not exhaustive.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [5.0.0] - Unreleased
+## [5.0.0] - 2026-07-06
 
 The **final-shape** major. `5.0.0` closes the validation contract
 (leading-zero padding is rejected by the acceptance predicates), makes
@@ -526,6 +526,7 @@ below cover the cases that do need attention:
 > Interim publishes `1.1.0`, `1.3.0`, and `1.3.1` (Apr–May 2024) were
 > incremental steps between the entries above and are not detailed separately.
 
+[5.0.0]: https://github.com/arrowsw/rut.ts/releases/tag/v5.0.0
 [4.1.0]: https://github.com/arrowsw/rut.ts/releases/tag/v4.1.0
 [4.0.1]: https://github.com/arrowsw/rut.ts/releases/tag/v4.0.1
 [4.0.0]: https://github.com/arrowsw/rut.ts/releases/tag/v4.0.0


### PR DESCRIPTION
The 5.0.0 release PR, per [RELEASING.md](./RELEASING.md) — contains **only** the CHANGELOG finalization:

- `## [5.0.0] - Unreleased` → `## [5.0.0] - 2026-07-06`
- Added the `[5.0.0]:` release-tag link definition to the footer (was missing)

**No version bump**: `package.json` has read `5.0.0` since #35 (the grandfathered in-branch bump — see RELEASING.md "State of play for 5.0.0").

## After squash-merging

```sh
git checkout canary && git pull
git tag v5.0.0
git push origin v5.0.0
```

The tag push triggers `publish.yml`: `npm ci` → `prepublishOnly` gate (tests + prettier + lint) → tag-vs-package.json check → `npm publish --provenance` (OIDC, tokenless). Then: GitHub Release from the tag pasting the `[5.0.0]` section, and update `www-rut.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013fFnDEM1NmE4no6TSY5tLr